### PR TITLE
Using vendordep.json for pulling in third party, grabbing native libraries

### DIFF
--- a/bazelrio/dependencies/colorsensor/1_2_0/deps.bzl
+++ b/bazelrio/dependencies/colorsensor/1_2_0/deps.bzl
@@ -19,6 +19,41 @@ cc_library_headers = """cc_library(
 def setup_colorsensor_dependencies():
     maybe(
         http_archive,
+        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_headers",
+        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-headers.zip",
+        sha256 = "bfa7bbfcb32017ed4e4c9b3138eea559f715b7c1fdf8666ed93938cd85787f70",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_windowsx86-64",
+        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-windowsx86-64.zip",
+        sha256 = "27c8a3b83c200fcf429b0f7f3466c59ab33db59a7dcaf2321f6a5a7a43914a74",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_windowsx86-64static",
+        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-windowsx86-64static.zip",
+        sha256 = "432587b2ceda321a23ffb8949b7d1ea1807fa525d0965797ec2ad9cfb410f491",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_linuxx86-64",
+        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-linuxx86-64.zip",
+        sha256 = "5539001938d3cab8e114c468dc6cc1cfcb87b5a1e34903839de21200f41fc80e",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_linuxx86-64static",
+        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-linuxx86-64static.zip",
+        sha256 = "fcbcde37d8f27e579d3274ca1a28a7c93841855885f8a22026f5438c685a1d6c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_linuxathena",
         url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-linuxathena.zip",
         sha256 = "2a14d0ab80f42402824b675c94f138b3137745b63770867053154ee1b4ded7bf",
@@ -26,8 +61,8 @@ def setup_colorsensor_dependencies():
     )
     maybe(
         http_archive,
-        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_headers",
-        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-headers.zip",
-        sha256 = "bfa7bbfcb32017ed4e4c9b3138eea559f715b7c1fdf8666ed93938cd85787f70",
-        build_file_content = cc_library_headers,
+        "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_linuxathenastatic",
+        url = "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/com/revrobotics/frc/ColorSensorV3-cpp/1.2.0/ColorSensorV3-cpp-1.2.0-linuxathenastatic.zip",
+        sha256 = "a5a2fa49786450c0a1049bb8485d12f9355242049db8fefc9e38423e91dec33c",
+        build_file_content = filegroup_all,
     )

--- a/bazelrio/dependencies/navx/4_0_425/deps.bzl
+++ b/bazelrio/dependencies/navx/4_0_425/deps.bzl
@@ -19,6 +19,13 @@ cc_library_headers = """cc_library(
 def setup_navx_dependencies():
     maybe(
         http_archive,
+        "__bazelrio_com_kauailabs_navx_frc_navx-cpp_headers",
+        url = "https://repo1.maven.org/maven2/com/kauailabs/navx/frc/navx-cpp/4.0.425/navx-cpp-4.0.425-headers.zip",
+        sha256 = "6482edc027dff06570e81747ff87aa8369b302122c38530b0cab0d2c11e83f80",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_com_kauailabs_navx_frc_navx-cpp_linuxathena",
         url = "https://repo1.maven.org/maven2/com/kauailabs/navx/frc/navx-cpp/4.0.425/navx-cpp-4.0.425-linuxathena.zip",
         sha256 = "6acf09ae05fe95b11c24370c4cc6a95f0feb65097f25e5c7e39b5d21b775d519",
@@ -26,8 +33,22 @@ def setup_navx_dependencies():
     )
     maybe(
         http_archive,
-        "__bazelrio_com_kauailabs_navx_frc_navx-cpp_headers",
-        url = "https://repo1.maven.org/maven2/com/kauailabs/navx/frc/navx-cpp/4.0.425/navx-cpp-4.0.425-headers.zip",
-        sha256 = "6482edc027dff06570e81747ff87aa8369b302122c38530b0cab0d2c11e83f80",
-        build_file_content = cc_library_headers,
+        "__bazelrio_com_kauailabs_navx_frc_navx-cpp_linuxathenastatic",
+        url = "https://repo1.maven.org/maven2/com/kauailabs/navx/frc/navx-cpp/4.0.425/navx-cpp-4.0.425-linuxathenastatic.zip",
+        sha256 = "a194cc44434733494cb92cd6d7f557b46bf6a4934e3381f2884f010481b4e263",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_kauailabs_navx_frc_navx-cpp_windowsx86-64",
+        url = "https://repo1.maven.org/maven2/com/kauailabs/navx/frc/navx-cpp/4.0.425/navx-cpp-4.0.425-windowsx86-64.zip",
+        sha256 = "616eaa091bfc0e7d954b92c47f26b496f46228fc7a24221beb6d5b7bd584cd2c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_kauailabs_navx_frc_navx-cpp_windowsx86-64static",
+        url = "https://repo1.maven.org/maven2/com/kauailabs/navx/frc/navx-cpp/4.0.425/navx-cpp-4.0.425-windowsx86-64static.zip",
+        sha256 = "8fd6e0c9a6aec8e67451e4f3a5ace597def6c6e60d3f6d51dcc403f04a8a4d3d",
+        build_file_content = filegroup_all,
     )

--- a/bazelrio/dependencies/phoenix/5_19_4/deps.bzl
+++ b/bazelrio/dependencies/phoenix/5_19_4/deps.bzl
@@ -40,6 +40,13 @@ def setup_phoenix_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_headers",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-headers.zip",
+        sha256 = "5eb70a62a1d99f531a63a88486822b22c057633009eef78151aa170e063ac6f9",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_com_ctre_phoenix_core_headers",
         url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-headers.zip",
         sha256 = "67bc9028b5ec447c972be02e7541520221aa819449634e15de7c90e7aa4fbdca",
@@ -50,6 +57,27 @@ def setup_phoenix_dependencies():
         "__bazelrio_com_ctre_phoenix_diagnostics_headers",
         url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-headers.zip",
         sha256 = "207597b7fb6579141510fd877a4cc031a3a5a9a11c063fd64e06c6bb727649a3",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_headers",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-headers.zip",
+        sha256 = "644f986291e9036c80ddb8791646f08635f1e988d4c14aaf429bbcc71b4857d6",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simtalonsrx_headers",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simTalonSRX/5.19.4/simTalonSRX-5.19.4-headers.zip",
+        sha256 = "83ebd5e6552b97094dc48329ae6fc2157e4586efe80bcfa584110c4f01938b29",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simvictorspx_headers",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simVictorSPX/5.19.4/simVictorSPX-5.19.4-headers.zip",
+        sha256 = "83ebd5e6552b97094dc48329ae6fc2157e4586efe80bcfa584110c4f01938b29",
         build_file_content = cc_library_headers,
     )
     maybe(
@@ -68,9 +96,79 @@ def setup_phoenix_dependencies():
     )
     maybe(
         http_archive,
-        "__bazelrio_com_ctre_phoenix_canutils_linuxathenastatic",
-        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-linuxathenastatic.zip",
-        sha256 = "473c5f9516b47d9f0663f49d3dc6b70f30eb418b6ba70def00cc35ac7b79cbf3",
+        "__bazelrio_com_ctre_phoenix_api-cpp_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/5.19.4/api-cpp-5.19.4-windowsx86-64.zip",
+        sha256 = "cbd1755f29e45ef17b7ad6279ef10b400debbc678001092f3bc8e80ea3083bca",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_api-cpp_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/5.19.4/api-cpp-5.19.4-windowsx86-64static.zip",
+        sha256 = "09c9cc2452da751a66ada9c6f927e5909b13db521c35608d84aa29309a7b146a",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_api-cpp_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/5.19.4/api-cpp-5.19.4-linuxx86-64static.zip",
+        sha256 = "753b92b82723755f101621aec9a0bb6a37fb249d02d1310934627ea9a1b829e7",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_api-cpp_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/api-cpp/5.19.4/api-cpp-5.19.4-osxx86-64static.zip",
+        sha256 = "97386037b983137146e2db8704a72609a5141da19d12f9b80b28d530c852c526",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_canutils_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-windowsx86-64.zip",
+        sha256 = "570e3047c1fbd5e44138e5a6864d074c8b28c0f8b26fe8b03ebe802078286fdc",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_canutils_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-windowsx86-64static.zip",
+        sha256 = "f578182a781d80c77abc47933e1d84a06bc200323f47cd3ac3ed4a1078633011",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_canutils_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-linuxx86-64.zip",
+        sha256 = "7856a4ecf8f14762c463a056b0db1dcf624c69621115645758b006b7797d86bd",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_canutils_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-linuxx86-64static.zip",
+        sha256 = "a903a57c251c29137ce8f8f380792a58f5766d8aaeaf18faf56561e202fba178",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_canutils_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-osxx86-64.zip",
+        sha256 = "9be88dfa318e6c6f4bc5c75180e55a491a17fb5e76b4bd8fbf66ca8ca3344c3c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_canutils_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/canutils/5.19.4/canutils-5.19.4-osxx86-64static.zip",
+        sha256 = "8de5be1e61d7ac471ee1d9d2dc9d7cccc6cc581cfbb65921791b85257af24c69",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_cci_linuxathena",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/cci/5.19.4/cci-5.19.4-linuxathena.zip",
+        sha256 = "8577b66f3b0fafe608277479963926c28e9b11a59bc8c7d34f7900fa75bd08f4",
         build_file_content = filegroup_all,
     )
     maybe(
@@ -82,9 +180,107 @@ def setup_phoenix_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-windowsx86-64.zip",
+        sha256 = "b3765072c82bfae16254ff017ae87d89dfa665f8b87624587d5a9a8872b1d333",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-windowsx86-64static.zip",
+        sha256 = "9c8b355260d7e43bfc65ae8426d09eb1f1e526971bc857c821ea968851b183a0",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-linuxx86-64.zip",
+        sha256 = "4f8d620cea3d379920ffaeff1183eba912bcd4867a3879522ea51f2375aff474",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-linuxx86-64static.zip",
+        sha256 = "a25c82b0e38fdbd20fd979a0cd560ca5b594c9c720c972e095ed65ffac1ff4a7",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-osxx86-64.zip",
+        sha256 = "e860c2f89f65b8dc9408e79e6e65cb928f2529e23fc0b050d4b8dfd4ce4c70e3",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_cci-sim_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/cci-sim/5.19.4/cci-sim-5.19.4-osxx86-64static.zip",
+        sha256 = "163ce5f844ba76a3d8813f14785e80a2d49515046745bcb3b240373de8dd8495",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_linuxathena",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-linuxathena.zip",
+        sha256 = "ffded28f0f9d76e076b96ed5a582b1c27cb82b7b64e8e6547ed77b5577a1d861",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_com_ctre_phoenix_core_linuxathenastatic",
         url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-linuxathenastatic.zip",
         sha256 = "28b0f497c043941898ba5ea0280dcdf133545b25ef98d5f2e493d02bc085584d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-windowsx86-64.zip",
+        sha256 = "424bc61752f28da1709e694fda119ad89fed42eb2bf4a5948b0afff94eb1270c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-windowsx86-64static.zip",
+        sha256 = "df0bc36d5416700eed9bdb0fc048de926d38fa82fbeb9d013beffb71523bc187",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-linuxx86-64.zip",
+        sha256 = "710d5245fbc1039872c6f337fc225e820231707ee67b97ad95ce085e5c3ddfde",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-linuxx86-64static.zip",
+        sha256 = "e42a0ce27de816763a7f28f1c99dabc296852dad5fc5c9b749ae4391a6c69e1c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-osxx86-64.zip",
+        sha256 = "8c632576ebd0bf01304c1c0b1f87a49b650ae2a2195acd13dcf2f35785e3780d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_core_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/core/5.19.4/core-5.19.4-osxx86-64static.zip",
+        sha256 = "264a19c04f1aebb450a65163e619f61440685728b27f29cba40713cfe4f6b7db",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_linuxathena",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-linuxathena.zip",
+        sha256 = "5bf312264b90e4fb26e7776af8753720c29a05928e2d60f246be1ab327ba1471",
         build_file_content = filegroup_all,
     )
     maybe(
@@ -96,8 +292,162 @@ def setup_phoenix_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-windowsx86-64.zip",
+        sha256 = "fdb3c0dd72701488b8896bc48e3d80fbcaf663b27ca3e46316bb7ecbfe074110",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-windowsx86-64static.zip",
+        sha256 = "354292a7d07b394cb68d73646ddbc00edc2783187129228a5183e611d50d7788",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-linuxx86-64.zip",
+        sha256 = "85f04f83ef812bb532e8cec1df74ce3983f833627809e5f580db7eb84be4c496",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-linuxx86-64static.zip",
+        sha256 = "3f515597d034475cd9c7430e51d7d2827dbf2a6ea43223d1d19c9e32ee29b34a",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-osxx86-64.zip",
+        sha256 = "12b4de2b9b40e2484a10c090197a43a94ffde13f5f791b72dac610c57d2bbd31",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_diagnostics_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/diagnostics/5.19.4/diagnostics-5.19.4-osxx86-64static.zip",
+        sha256 = "6a6daee043daa974bb752c8726cfbbb24e3535fd48d777a35423cb174742107d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-windowsx86-64.zip",
+        sha256 = "983484c7fbb426fa369b36283e50eb59c69708eb4241dbbdc07d880e59b015c8",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-windowsx86-64static.zip",
+        sha256 = "4fa28b69007167731dae970b91449e74a3c34e8d5180d0aa7db9b53f4c5717ac",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-linuxx86-64.zip",
+        sha256 = "b367c10838893676a62d18adaf2a58c267bdb804b5ef0d79a112df77148c7b3c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-linuxx86-64static.zip",
+        sha256 = "51488c4933d4954d3772926754766a3b43cc33169225b5eb28db8709f71388b1",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-osxx86-64.zip",
+        sha256 = "0086845681831206ee80d331a74acaecf8be4af0356f3ab8f0ffd69f93b68bae",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_platform-sim_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/platform-sim/5.19.4/platform-sim-5.19.4-osxx86-64static.zip",
+        sha256 = "81ec65137d7a5242087157e37aa5ac11a38eb7a60a705db5e75dead7d11a897b",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simtalonsrx_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simTalonSRX/5.19.4/simTalonSRX-5.19.4-windowsx86-64.zip",
+        sha256 = "5f0ef9867f9bdb4cd6d1a6b306ae1d153d24a71dffc73b4893b45a3271399b35",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simtalonsrx_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simTalonSRX/5.19.4/simTalonSRX-5.19.4-linuxx86-64.zip",
+        sha256 = "6f64470deb99eef63e46083e5d54f9c9f04a0ce9ce0bca96d99c54953ccec15b",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simtalonsrx_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simTalonSRX/5.19.4/simTalonSRX-5.19.4-osxx86-64.zip",
+        sha256 = "4b06a52ff326df631699eddf9c4febf422ec7595bd68920095bca4f2116fb2a6",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simvictorspx_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simVictorSPX/5.19.4/simVictorSPX-5.19.4-windowsx86-64.zip",
+        sha256 = "e78688c15feed1d40ec5a176376bd2fbd39fee7f7def7ce59e1d49c3089832f4",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simvictorspx_linuxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simVictorSPX/5.19.4/simVictorSPX-5.19.4-linuxx86-64.zip",
+        sha256 = "a32259c3513bbdf0b256ce4a70678c7fd58d5fb1e4e48a593470b1f362498d04",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_sim_simvictorspx_osxx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/sim/simVictorSPX/5.19.4/simVictorSPX-5.19.4-osxx86-64.zip",
+        sha256 = "f121bc5c47750d8f3a30c64db461930e024baaf13b36c293c3f606014ecd353f",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_com_ctre_phoenix_wpiapi-cpp_linuxathenastatic",
         url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/5.19.4/wpiapi-cpp-5.19.4-linuxathenastatic.zip",
         sha256 = "f9976026d4ed2f3b3277cae80384f3a433e7ff98e80cffda58f64eff9fc65731",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_wpiapi-cpp_windowsx86-64",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/5.19.4/wpiapi-cpp-5.19.4-windowsx86-64.zip",
+        sha256 = "0c11e1951f29f567cf5aeead23eea451c6d58f8e8f3b70d6fa688c8804997507",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_wpiapi-cpp_windowsx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/5.19.4/wpiapi-cpp-5.19.4-windowsx86-64static.zip",
+        sha256 = "3e2f9f6e40a7eebe0f788ac6b33a4bd14426032f91831d335b92522e67cfacc8",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_wpiapi-cpp_linuxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/5.19.4/wpiapi-cpp-5.19.4-linuxx86-64static.zip",
+        sha256 = "bd2561045c21309f761faa5ced2f9081166daa331c1ba999ca3898dffbd79827",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_ctre_phoenix_wpiapi-cpp_osxx86-64static",
+        url = "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/wpiapi-cpp/5.19.4/wpiapi-cpp-5.19.4-osxx86-64static.zip",
+        sha256 = "827867aaf3f6f0f2454a4b540413581ddd62916647f9ea92fd54071d63313555",
         build_file_content = filegroup_all,
     )

--- a/bazelrio/dependencies/sparkmax/1_5_4/deps.bzl
+++ b/bazelrio/dependencies/sparkmax/1_5_4/deps.bzl
@@ -19,20 +19,6 @@ cc_library_headers = """cc_library(
 def setup_sparkmax_dependencies():
     maybe(
         http_archive,
-        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxathena",
-        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-linuxathena.zip",
-        sha256 = "df0c97373fa3c033a552cf15d5b9afcd6d9231737f6bca8cf1c4df63c2d30658",
-        build_file_content = filegroup_all,
-    )
-    maybe(
-        http_archive,
-        "__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxathena",
-        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-linuxathena.zip",
-        sha256 = "85f430e7f14635e4556d5e9147d9dda7f0180f6b487f8959c96a635424b8f11a",
-        build_file_content = filegroup_all,
-    )
-    maybe(
-        http_archive,
         "__bazelrio_com_revrobotics_frc_sparkmax-cpp_headers",
         url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-headers.zip",
         sha256 = "e5c5c8c3e72b399101ee1056279d72540554ffb149d9351036f8d977b36e3c1f",
@@ -44,4 +30,116 @@ def setup_sparkmax_dependencies():
         url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-headers.zip",
         sha256 = "c3984a9c073125bedb1a299c1e8e831b43e728b83dbc10d8e0032cb74186fed2",
         build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_windowsx86-64",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-windowsx86-64.zip",
+        sha256 = "d8db275ce8b3ff2850a465486804bf85fbb25022183254be53630e959d6a4753",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_windowsx86-64static",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-windowsx86-64static.zip",
+        sha256 = "5f7b16af472c7eb334351206a8398c920458b782cbd77c0e6f8c0395b18534d6",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxx86-64",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-linuxx86-64.zip",
+        sha256 = "a4b47bb6f8ee872d38a14ed6d807fd33b26273b6979d722a2c72cceb5ac3b75c",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxx86-64static",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-linuxx86-64static.zip",
+        sha256 = "a0b95a982975a258f9ea0e44b02b2e6429e0d5fa3ebdaea0192bf52259ae5724",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxathena",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-linuxathena.zip",
+        sha256 = "df0c97373fa3c033a552cf15d5b9afcd6d9231737f6bca8cf1c4df63c2d30658",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxathenastatic",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-linuxathenastatic.zip",
+        sha256 = "02442954014ad8439cb277351bbb373deb5a898391777baa66f63bdf0f4e000d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_osxx86-64",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-osxx86-64.zip",
+        sha256 = "cfbf81fe88cc5fd3c9a1390b2414fffe835abccd285118df7049911709884992",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-cpp_osxx86-64static",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-cpp/1.5.4/SparkMax-cpp-1.5.4-osxx86-64static.zip",
+        sha256 = "f02fe4702f9d548ed35fb44f352e0767044ce17808f5f8bda79d3c4eaf75220e",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_windowsx86-64",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-windowsx86-64.zip",
+        sha256 = "4ca674c6e4fcb72410a96ec69d654b96c251244268e70892858badaeb1c831ac",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_windowsx86-64static",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-windowsx86-64static.zip",
+        sha256 = "9817941c76fcb421bc8c052a2c92e4056207c2ab565bc0545be73d6f53d496d8",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxx86-64",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-linuxx86-64.zip",
+        sha256 = "5d074a8e3ea590bbf84d8010ce2dbfb5f960418955cbbb0fc66cd653c07d0084",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxx86-64static",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-linuxx86-64static.zip",
+        sha256 = "f880873a0e02984165f10549f0b3f05072648f22f800604a8fc9b8118191fbe1",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxathena",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-linuxathena.zip",
+        sha256 = "85f430e7f14635e4556d5e9147d9dda7f0180f6b487f8959c96a635424b8f11a",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxathenastatic",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-linuxathenastatic.zip",
+        sha256 = "43c6bb9c5ec30cc854397200f03b9833cca760eaf526513bd44250b38597ebe3",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_osxx86-64",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-osxx86-64.zip",
+        sha256 = "6e9d0902d2a6a36f6e58df763144fbdb211af25fe9c348848a8e13015cbb5990",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_com_revrobotics_frc_sparkmax-driver_osxx86-64static",
+        url = "http://www.revrobotics.com/content/sw/max/sdk/maven/com/revrobotics/frc/SparkMax-driver/1.5.4/SparkMax-driver-1.5.4-osxx86-64static.zip",
+        sha256 = "13c0e148bfccea862476c6c32aad878d021fb907d723fc7093e816dc0ecf5c05",
+        build_file_content = filegroup_all,
     )

--- a/bazelrio/dependencies/wpilib/2021_3_1/deps.bzl
+++ b/bazelrio/dependencies/wpilib/2021_3_1/deps.bzl
@@ -26,6 +26,27 @@ def setup_wpilib_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_edu_wpi_first_wpilibc_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibc/wpilibc-cpp/2021.3.1/wpilibc-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "b3f3e6d4958a8f4b72e49df6658f5f3fcdc5114537b49f26263b04cc2c94edf4",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpilibc_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibc/wpilibc-cpp/2021.3.1/wpilibc-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "8f4cc72163713512fcaddfc9f3f1790376659f6aaa2ed55c47155ca0b52a7169",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpilibc_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibc/wpilibc-cpp/2021.3.1/wpilibc-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "9a0a8ac63c4d645d938e37ca4da0a040fc48a38e6d5f8689aa9c8eddec024600",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_edu_wpi_first_wpilibc_headers",
         url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibc/wpilibc-cpp/2021.3.1/wpilibc-cpp-2021.3.1-headers.zip",
         sha256 = "c1bb5ba16138be092c52664147d26b45347d68fdb086c483c7ca8f6383bcab87",
@@ -36,6 +57,27 @@ def setup_wpilib_dependencies():
         "__bazelrio_edu_wpi_first_hal_linuxathena",
         url = "https://frcmaven.wpi.edu/release/edu/wpi/first/hal/hal-cpp/2021.3.1/hal-cpp-2021.3.1-linuxathena.zip",
         sha256 = "e9de32abe3739697a3a92963c9eca4bf8755edfb0f11ac95e22d0190a3185f56",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_hal_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/hal/hal-cpp/2021.3.1/hal-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "18d860d1be5dfcf104f9609f9bb2af666fda13e8d3608ef9b9e890b5c4c56785",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_hal_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/hal/hal-cpp/2021.3.1/hal-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "48ca6f22deb800170c801944531557c8d109be4501418c719349519405ae6cc2",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_hal_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/hal/hal-cpp/2021.3.1/hal-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "46f76a6ba82f395e19ba48c12c56b1d864b03f46498a0f42b6a15fe12d3aaa6a",
         build_file_content = filegroup_all,
     )
     maybe(
@@ -54,6 +96,27 @@ def setup_wpilib_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_edu_wpi_first_wpiutil_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpiutil/wpiutil-cpp/2021.3.1/wpiutil-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "5e85e0a32ed520c1ea075087b3701769f2007fe8a9385831b1d947f70179cf8f",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpiutil_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpiutil/wpiutil-cpp/2021.3.1/wpiutil-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "4a20ec638981025c0e41678ac7cea691d5a40121987b1309e6907255636d02cf",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpiutil_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpiutil/wpiutil-cpp/2021.3.1/wpiutil-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "09c7914e5fcf4b26967e0bddb501c79d054de276a5724a9089b0e04d9e13e640",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_edu_wpi_first_wpiutil_headers",
         url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpiutil/wpiutil-cpp/2021.3.1/wpiutil-cpp-2021.3.1-headers.zip",
         sha256 = "b2a96f7ce07198b139face9dc341c6550d5044fa32f48435b50d986ea5c8ee55",
@@ -64,6 +127,27 @@ def setup_wpilib_dependencies():
         "__bazelrio_edu_wpi_first_ntcore_linuxathena",
         url = "https://frcmaven.wpi.edu/release/edu/wpi/first/ntcore/ntcore-cpp/2021.3.1/ntcore-cpp-2021.3.1-linuxathena.zip",
         sha256 = "dabb3d971cf0aee46d4b104d38abd47cc36219b025b299bfb9fea82e53deacc7",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_ntcore_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/ntcore/ntcore-cpp/2021.3.1/ntcore-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "cd69aba9cc0b16fda738dcde53b1c8c138c616fd4af2e2de1877f66973fcc6d3",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_ntcore_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/ntcore/ntcore-cpp/2021.3.1/ntcore-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "d6aedae1639db0fd538f7c519b97cf45441a6ec7c8220c3f564d7c3a7de71294",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_ntcore_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/ntcore/ntcore-cpp/2021.3.1/ntcore-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "8daf5d2b4cf3e16db6b3ad3a309aade6315b9458abeb40b94d59cbb21ddac087",
         build_file_content = filegroup_all,
     )
     maybe(
@@ -82,9 +166,100 @@ def setup_wpilib_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_edu_wpi_first_wpimath_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpimath/wpimath-cpp/2021.3.1/wpimath-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "2ec3dcf69a2b0500aea1d5037aa79912a252c5c7f8aefd113c974e1559d88cf9",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpimath_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpimath/wpimath-cpp/2021.3.1/wpimath-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "d5edb77e3ed15df710c7895636190ee2f89e47429f2925e015bd7b0025af4612",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpimath_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpimath/wpimath-cpp/2021.3.1/wpimath-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "4d61ca32079050b825d5ee543a8293f52fb0cfca0d71d7c4bdd3f58cc689b73d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_edu_wpi_first_wpimath_headers",
         url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpimath/wpimath-cpp/2021.3.1/wpimath-cpp-2021.3.1-headers.zip",
         sha256 = "dac88ad40484aaa6721d190c23b33668fa11a86e32877458285c2ea678db54d3",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cameraserver_linuxathena",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cameraserver/cameraserver-cpp/2021.3.1/cameraserver-cpp-2021.3.1-linuxathena.zip",
+        sha256 = "d12ec6b78a3453c5e3cab275827abb1be2142e077532fc7dc32d03f36d04b3e8",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cameraserver_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cameraserver/cameraserver-cpp/2021.3.1/cameraserver-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "c50e11d6feca3042e55c579a4cb9ead695b1f2d6ce4a0d3599533bd83521e7bf",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cameraserver_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cameraserver/cameraserver-cpp/2021.3.1/cameraserver-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "2dbc4342d770995c7a53ca3fa984e55947a1049bf2a561d145671318c04277ce",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cameraserver_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cameraserver/cameraserver-cpp/2021.3.1/cameraserver-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "b2353da4a8a68580a2c8aaaa348b80fc5903fb996c9747650735cdc272110885",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cameraserver_headers",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cameraserver/cameraserver-cpp/2021.3.1/cameraserver-cpp-2021.3.1-headers.zip",
+        sha256 = "20822383b8a56d781f46a60023f2c49b3e80014af504b74a6793fc034cb1c13c",
+        build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cscore_linuxathena",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cscore/cscore-cpp/2021.3.1/cscore-cpp-2021.3.1-linuxathena.zip",
+        sha256 = "53fed9fb2526f52f88571803e63a35337f173197b19f041fdc70ee82f5846eec",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cscore_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cscore/cscore-cpp/2021.3.1/cscore-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "02f8bdc027ac0779f7a97f2ac0996cf4884600868564a6534edef4eed45cf426",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cscore_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cscore/cscore-cpp/2021.3.1/cscore-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "457668d0e9833e96e25c3581b47d6855cecdf137f79f906cd8c104dba0415791",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cscore_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cscore/cscore-cpp/2021.3.1/cscore-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "e54461b678c838320304a28341c8031ff5d5d80cdd851cc525a1daa0f394cb1e",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_cscore_headers",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/cscore/cscore-cpp/2021.3.1/cscore-cpp-2021.3.1-headers.zip",
+        sha256 = "4ff4560b32aaa664ca0869412c5ddd2bc2ed48ce9d9c771ece7a74c7df787e40",
         build_file_content = cc_library_headers,
     )
     maybe(
@@ -96,8 +271,113 @@ def setup_wpilib_dependencies():
     )
     maybe(
         http_archive,
+        "__bazelrio_edu_wpi_first_wpilibnewcommands_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibNewCommands/wpilibNewCommands-cpp/2021.3.1/wpilibNewCommands-cpp-2021.3.1-windowsx86-64.zip",
+        sha256 = "9f819677632b807a7157b953ea81a8544cd5b31bfa54012dd1b3402dbdb5f748",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpilibnewcommands_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibNewCommands/wpilibNewCommands-cpp/2021.3.1/wpilibNewCommands-cpp-2021.3.1-linuxx86-64.zip",
+        sha256 = "208a85c8d238b17770fe1602fce027819d5b778eb438fa6ae09f971254f90a81",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_wpilibnewcommands_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibNewCommands/wpilibNewCommands-cpp/2021.3.1/wpilibNewCommands-cpp-2021.3.1-osxx86-64.zip",
+        sha256 = "fd4b06175d22183ce97b0f8e2f47a103d8c32b45e67640d351ebc38e42c397b8",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
         "__bazelrio_edu_wpi_first_wpilibnewcommands_headers",
         url = "https://frcmaven.wpi.edu/release/edu/wpi/first/wpilibNewCommands/wpilibNewCommands-cpp/2021.3.1/wpilibNewCommands-cpp-2021.3.1-headers.zip",
         sha256 = "c919969657ce44a5a20cc84140997149082dbfda5cda7f170b68d2e94744921e",
         build_file_content = cc_library_headers,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ds_socket_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ds_socket/2021.3.1/halsim_ds_socket-2021.3.1-windowsx86-64.zip",
+        sha256 = "ece35a6e537c278d4e723d06f38b70248d268e77ff03642446e3ef407b3c6ba0",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ds_socket_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ds_socket/2021.3.1/halsim_ds_socket-2021.3.1-linuxx86-64.zip",
+        sha256 = "fed2c510c7d1306914fcac1e07b8b0b09d61ea12d92afc70714d6843122f8128",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ds_socket_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ds_socket/2021.3.1/halsim_ds_socket-2021.3.1-osxx86-64.zip",
+        sha256 = "72906f39507b6babe5864929d0c32d40b4f688615a36113ceefc07c323429b10",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_gui_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_gui/2021.3.1/halsim_gui-2021.3.1-windowsx86-64.zip",
+        sha256 = "6f7c04b1f1a17fced091b9057579837ca82909e17565140be77ffbd9eb6db679",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_gui_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_gui/2021.3.1/halsim_gui-2021.3.1-linuxx86-64.zip",
+        sha256 = "d77274cc63b382163b7c24ea54ff2b54570d23e109f7d3488785d6b9c263023f",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_gui_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_gui/2021.3.1/halsim_gui-2021.3.1-osxx86-64.zip",
+        sha256 = "e5da5864c4c75367e7627f074b3351a2031c1fc56f3a05f2ec42dc20e819aa4e",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ws_client_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ws_client/2021.3.1/halsim_ws_client-2021.3.1-windowsx86-64.zip",
+        sha256 = "80071475655a31cfe3c49cc1dd76cbf1136c12935789c279ff6727bc3dba238a",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ws_client_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ws_client/2021.3.1/halsim_ws_client-2021.3.1-linuxx86-64.zip",
+        sha256 = "da3cbc93ac263b2ccf4de7945d31861b3f247b7c42089cc9317c96c627c68537",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ws_client_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ws_client/2021.3.1/halsim_ws_client-2021.3.1-osxx86-64.zip",
+        sha256 = "e4ec269f9f26240bfd4c7711ed232340477c2e11be8594dc8a7c2c1a7591b39d",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ws_server_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ws_server/2021.3.1/halsim_ws_server-2021.3.1-windowsx86-64.zip",
+        sha256 = "89e3c28065a95adb925ea24813838450da10a585d4aaa837d18fe70c3c1db61a",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ws_server_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ws_server/2021.3.1/halsim_ws_server-2021.3.1-linuxx86-64.zip",
+        sha256 = "ccbc351ded760015279e74ef0cbc216073714cb72b1f2ef04253ab38861d19e0",
+        build_file_content = filegroup_all,
+    )
+    maybe(
+        http_archive,
+        "__bazelrio_edu_wpi_first_halsim_halsim_ws_server_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/halsim/halsim_ws_server/2021.3.1/halsim_ws_server-2021.3.1-osxx86-64.zip",
+        sha256 = "4810a7254c60d1b90eb840c705aa30f0a326964b16eaac70aac70bf51d691eae",
+        build_file_content = filegroup_all,
     )

--- a/scripts/dependencies.py
+++ b/scripts/dependencies.py
@@ -3,9 +3,15 @@ from os.path import join, exists
 from json import loads
 from typing import Union
 from urllib.request import urlopen
+from urllib.error import HTTPError
 from hashlib import sha256 as sha256sum
+import os
+import json
 
-DEPENDENCIES_PATH = join("bazelrio", "deps.bzl")
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+OUTPUT_DIRECTORY_BASE = os.path.join(SCRIPT_DIR, "..")
+
+DEPENDENCIES_PATH = join(OUTPUT_DIRECTORY_BASE, "bazelrio", "deps.bzl")
 WPILIB_VERSION = "2021.3.1"
 NI_VERSION = "2020.9.2"
 REV_SPARKMAX_VERSION = "1.5.4"
@@ -13,7 +19,8 @@ REV_COLORSENSOR_VERSION = "1.2.0"
 CTRE_PHOENIX_VERSION = "5.19.4"
 KAUAILABS_NAVX_VERSION = "4.0.425"
 
-PLATFORMS = ["linuxathena"]
+DEFAULT_NATIVE_SHARED_PLATFORMS = ["windowsx86-64", "linuxx86-64", "osxx86-64"]
+DEFAULT_PLATFORMS = ["linuxathena"] + DEFAULT_NATIVE_SHARED_PLATFORMS
 
 
 def http_get(url: str) -> bytes:
@@ -56,7 +63,7 @@ def maven(
     if sha256 is None:
         try:
             sha256 = http_get(url + ".sha256").decode("utf-8")
-        except:
+        except HTTPError:
             print("Downloading this to calculate SHA 256 sum...")
             sha256 = sha256sum(http_get(url)).hexdigest()
 
@@ -71,19 +78,19 @@ def maven(
 
 
 def wpilib_dependency(
-    project: str, resources=PLATFORMS + ["headers"], language="cpp"
+    project: str, resources=DEFAULT_PLATFORMS + ["headers"], language="cpp", path="edu/wpi/first"
 ) -> str:
     dependencies = ""
     for resource in resources:
         sha256 = loads(
             http_get(
-                f"https://frcmaven.wpi.edu/api/storage/wpilib-mvn-release/{resource_path('edu/wpi/first', project, language, WPILIB_VERSION, resource)}"
+                f"https://frcmaven.wpi.edu/api/storage/wpilib-mvn-release/{resource_path(path, project, language, WPILIB_VERSION, resource)}"
             )
         )["checksums"]["sha256"]
 
         dependencies += maven(
             "https://frcmaven.wpi.edu/release",
-            "edu/wpi/first",
+            path,
             project,
             language,
             WPILIB_VERSION,
@@ -92,6 +99,13 @@ def wpilib_dependency(
         )
 
     return dependencies
+
+
+def halsim_dependency(project: str) -> str:
+    return wpilib_dependency(project,
+                             path="edu/wpi/first/halsim",
+                             resources=DEFAULT_NATIVE_SHARED_PLATFORMS,
+                             language=None)
 
 
 def ni_dependency(project: str, language=None, resources=["linuxathena"]) -> str:
@@ -115,8 +129,67 @@ def ni_dependency(project: str, language=None, resources=["linuxathena"]) -> str
     return dependencies
 
 
+def parse_vendor_dep(dependency_name, vendor_dep_file):
+    PLATFORM_BLACKLIST = set([
+        "windowsx86",
+        "linuxaarch64bionic",
+        "linuxraspbian",
+    ])
+
+    with open(vendor_dep_file, 'r') as f:
+        vendor_dep = json.load(f)
+
+    header_dependencies = ""
+    library_dependencies = ""
+
+    for cpp_dep in sorted(vendor_dep["cppDependencies"], key=lambda x: x['artifactId']):
+        site = vendor_dep['mavenUrls'][0]
+        if site.endswith("/"):
+            site = site[:-1]
+
+        common_args = {}
+        common_args['site'] = site
+        common_args['path'] = cpp_dep['groupId'].replace(".", "/")
+        common_args['name'] = cpp_dep['artifactId']
+        common_args['language'] = None
+        common_args['version'] = vendor_dep['version']
+
+        # Header
+        header_dependencies += maven(
+            resource=cpp_dep['headerClassifier'],
+            **common_args,
+        )
+
+        # Libraries
+        for platform in cpp_dep["binaryPlatforms"]:
+            if platform in PLATFORM_BLACKLIST:
+                continue
+
+            # The vendors aren't good at making vendordeps.json. They often
+            # include bogus data, and aren't consistent about publishing
+            # what they are supposed to, so give it a best effort and fail
+            # quietly.
+            try:
+                library_dependencies += maven(
+                    resource=platform,
+                    **common_args,
+                )
+            except HTTPError:
+                print(f"No shared library for {cpp_dep['artifactId']}")
+
+            try:
+                library_dependencies += maven(
+                    resource=platform + "static",
+                    **common_args,
+                )
+            except HTTPError:
+                print(f"No static library for {cpp_dep['artifactId']}")
+
+    return create_dependency(dependency_name, vendor_dep['version'], header_dependencies + library_dependencies)
+
+
 def create_dependency(project: str, version: str, dependencies: str):
-    folder = join("bazelrio", "dependencies", project, version.replace(".", "_"))
+    folder = join(OUTPUT_DIRECTORY_BASE, "bazelrio", "dependencies", project, version.replace(".", "_"))
     if not exists(folder):
         makedirs(folder)
 
@@ -159,108 +232,60 @@ def {method_name}():"""
     )
 
 
-dependencies = []
+def main():
+    dependencies = []
 
-dependencies.append(
-    create_dependency(
-        "wpilib",
-        WPILIB_VERSION,
-        wpilib_dependency("wpilibc")
-        + wpilib_dependency("hal")
-        + wpilib_dependency("wpiutil")
-        + wpilib_dependency("ntcore")
-        + wpilib_dependency("wpimath")
-        + wpilib_dependency("wpilibNewCommands"),
-    )
-)
-dependencies.append(
-    create_dependency(
-        "ni",
-        NI_VERSION,
-        ni_dependency("chipobject")
-        + ni_dependency("visa")
-        + ni_dependency("runtime")
-        + ni_dependency("netcomm"),
-    )
-)
-
-sparkmax_dependencies = ""
-colorsensor_dependencies = ""
-phoenix_dependencies = ""
-navx_dependencies = ""
-
-for resource in PLATFORMS + ["headers"]:
-    sparkmax_dependencies += maven(
-        "http://www.revrobotics.com/content/sw/max/sdk/maven",
-        "com/revrobotics/frc",
-        "SparkMax-cpp",
-        None,
-        REV_SPARKMAX_VERSION,
-        resource,
-    )
-
-    sparkmax_dependencies += maven(
-        "http://www.revrobotics.com/content/sw/max/sdk/maven",
-        "com/revrobotics/frc",
-        "SparkMax-driver",
-        None,
-        REV_SPARKMAX_VERSION,
-        resource,
-    )
-
-    colorsensor_dependencies += maven(
-        "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven",
-        "com/revrobotics/frc",
-        "ColorSensorV3-cpp",
-        None,
-        REV_COLORSENSOR_VERSION,
-        resource,
-    )
-
-    navx_dependencies += maven(
-        "https://repo1.maven.org/maven2",
-        "com/kauailabs/navx/frc",
-        "navx-cpp",
-        None,
-        KAUAILABS_NAVX_VERSION,
-        resource,
-    )
-
-for resource in ["headers", "linuxathenastatic"]:
-    for project in ["api-cpp", "canutils", "cci", "core", "diagnostics", "wpiapi-cpp"]:
-        phoenix_dependencies += maven(
-            "https://devsite.ctr-electronics.com/maven/release",
-            "com/ctre/phoenix",
-            project,
-            None,
-            CTRE_PHOENIX_VERSION,
-            resource,
+    dependencies.append(
+        create_dependency(
+            "wpilib",
+            WPILIB_VERSION,
+            wpilib_dependency("wpilibc")
+            + wpilib_dependency("hal")
+            + wpilib_dependency("wpiutil")
+            + wpilib_dependency("ntcore")
+            + wpilib_dependency("wpimath")
+            + wpilib_dependency("cameraserver")
+            + wpilib_dependency("cscore")
+            + wpilib_dependency("wpilibNewCommands")
+            + halsim_dependency("halsim_ds_socket")
+            + halsim_dependency("halsim_gui")
+            + halsim_dependency("halsim_ws_client")
+            + halsim_dependency("halsim_ws_server"),
         )
+    )
+    dependencies.append(
+        create_dependency(
+            "ni",
+            NI_VERSION,
+            ni_dependency("chipobject")
+            + ni_dependency("visa")
+            + ni_dependency("runtime")
+            + ni_dependency("netcomm"),
+        )
+    )
 
-dependencies.append(
-    create_dependency("sparkmax", REV_SPARKMAX_VERSION, sparkmax_dependencies)
-)
-dependencies.append(
-    create_dependency("colorsensor", REV_COLORSENSOR_VERSION, colorsensor_dependencies)
-)
-dependencies.append(
-    create_dependency("phoenix", CTRE_PHOENIX_VERSION, phoenix_dependencies)
-)
-dependencies.append(
-    create_dependency("navx", KAUAILABS_NAVX_VERSION, navx_dependencies)
-)
+    dependencies.append(parse_vendor_dep("sparkmax", f"vendordeps/sparkmax/{REV_SPARKMAX_VERSION}.json"))
+    dependencies.append(parse_vendor_dep("colorsensor", f"vendordeps/colorsensor/{REV_COLORSENSOR_VERSION}.json"))
+    dependencies.append(parse_vendor_dep("phoenix", f"vendordeps/phoenix/{CTRE_PHOENIX_VERSION}.json"))
+    dependencies.append(parse_vendor_dep("navx", f"vendordeps/navx/{KAUAILABS_NAVX_VERSION}.json"))
 
-contents = open(join("bazelrio", "deps.bzl"), "r").read().split("# THE FOLLOWING LINES")
 
-contents[1] = contents[1].split("\n")[0]
-contents[3] = contents[3].split("\n")[0]
+    main_dep_file = join(OUTPUT_DIRECTORY_BASE, "bazelrio", "deps.bzl")
+    contents = open(main_dep_file, "r").read().split("# THE FOLLOWING LINES")
 
-contents[1] += (
-    "\n" + "\n".join(map(lambda dependency: dependency[0], dependencies)) + "\n"
-)
-contents[3] += "\n    " + (
-    "\n    ".join(map(lambda dependency: dependency[1] + "()", dependencies)) + "\n    "
-)
+    contents[1] = contents[1].split("\n")[0]
+    contents[3] = contents[3].split("\n")[0]
 
-with open(join("bazelrio", "deps.bzl"), "w") as deps:
-    deps.write("# THE FOLLOWING LINES".join(contents))
+    contents[1] += (
+        "\n" + "\n".join(map(lambda dependency: dependency[0], dependencies)) + "\n"
+    )
+    contents[3] += "\n    " + (
+        "\n    ".join(map(lambda dependency: dependency[1] + "()", dependencies)) + "\n    "
+    )
+
+    with open(main_dep_file, "w") as deps:
+        deps.write("# THE FOLLOWING LINES".join(contents))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vendordeps/colorsensor/1.2.0.json
+++ b/scripts/vendordeps/colorsensor/1.2.0.json
@@ -1,0 +1,37 @@
+{
+    "cppDependencies": [
+        {
+            "artifactId": "ColorSensorV3-cpp",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "ColorSensorV3",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "sourcesClassifier": "source",
+            "version": "1.2.0"
+        }
+    ],
+    "fileName": "REVColorSensorV3.json",
+    "javaDependencies": [
+        {
+            "artifactId": "ColorSensorV3-java",
+            "groupId": "com.revrobotics.frc",
+            "version": "1.2.0"
+        }
+    ],
+    "jniDependencies": [],
+    "jsonUrl": "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/REVColorSensorV3.json",
+    "mavenUrls": [
+        "http://www.revrobotics.com/content/sw/color-sensor-v3/sdk/maven/"
+    ],
+    "name": "REVColorSensorV3",
+    "uuid": "cda7b4b1-d003-44ac-a1ef-485c1347059a",
+    "version": "1.2.0"
+}

--- a/scripts/vendordeps/navx/4.0.425.json
+++ b/scripts/vendordeps/navx/4.0.425.json
@@ -1,0 +1,35 @@
+{
+    "fileName": "navx_frc.json",
+    "name": "KauaiLabs_navX_FRC",
+    "version": "4.0.425",
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "mavenUrls": [
+        "https://repo1.maven.org/maven2/"
+    ],
+    "jsonUrl": "https://www.kauailabs.com/dist/frc/2021/navx_frc.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-java",
+            "version": "4.0.425"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-cpp",
+            "version": "4.0.425",
+            "headerClassifier": "headers",
+            "sourcesClassifier": "sources",
+            "sharedLibrary": false,
+            "libName": "navx_frc",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "linuxraspbian",
+                "windowsx86-64"
+            ]
+        }
+    ]
+}

--- a/scripts/vendordeps/phoenix/5.19.4.json
+++ b/scripts/vendordeps/phoenix/5.19.4.json
@@ -1,0 +1,214 @@
+{
+    "fileName": "Phoenix.json",
+    "name": "CTRE-Phoenix",
+    "version": "5.19.4",
+    "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
+    "mavenUrls": [
+        "https://devsite.ctr-electronics.com/maven/release/"
+    ],
+    "jsonUrl": "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-java",
+            "version": "5.19.4"
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-java",
+            "version": "5.19.4"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "wpiapi-cpp",
+            "version": "5.19.4",
+            "libName": "CTRE_Phoenix_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "api-cpp",
+            "version": "5.19.4",
+            "libName": "CTRE_Phoenix",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "cci",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCCI",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "diagnostics",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixDiagnostics",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "canutils",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCanutils",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "platform-sim",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixPlatform",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix",
+            "artifactId": "core",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCore",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        }
+    ]
+}

--- a/scripts/vendordeps/sparkmax/1.5.4.json
+++ b/scripts/vendordeps/sparkmax/1.5.4.json
@@ -1,0 +1,73 @@
+{
+    "cppDependencies": [
+        {
+            "artifactId": "SparkMax-cpp",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMax",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.4"
+        },
+        {
+            "artifactId": "SparkMax-driver",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMaxDriver",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.4"
+        }
+    ],
+    "fileName": "REVRobotics.json",
+    "javaDependencies": [
+        {
+            "artifactId": "SparkMax-java",
+            "groupId": "com.revrobotics.frc",
+            "version": "1.5.4"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "artifactId": "SparkMax-driver",
+            "groupId": "com.revrobotics.frc",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian",
+                "osxx86-64"
+            ],
+            "version": "1.5.4"
+        }
+    ],
+    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
+    "mavenUrls": [
+        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+    ],
+    "name": "REVRobotics",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "version": "1.5.4"
+}


### PR DESCRIPTION
- Pulls in both static and shared libraries, for linuxathena, osx, linux, and windows
- Pulling in some additional allwpilib libraries, like cscore, cameraserver, and the halsim plugins
- Uses vendordeps to pull in third party things. There were native tools missing for CTRE, and this will make it easier to update / add new ones if the vendors add libraries (like CTRE did to support sim last year)
- Caching the versioned vendordeps.json, since they can disappear on you once it is no longer the latest (REV seems to do this)