### PR TITLE
Prep work for newer versions

### DIFF
--- a/bazelrio/dependencies/colorsensor/1_2_0/deps.bzl
+++ b/bazelrio/dependencies/colorsensor/1_2_0/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
 
-def setup_colorsensor_dependencies():
+def setup_colorsensor_1_2_0_dependencies():
     maybe(
         http_archive,
         "__bazelrio_com_revrobotics_frc_colorsensorv3-cpp_headers",

--- a/bazelrio/dependencies/colorsensor/deps.bzl
+++ b/bazelrio/dependencies/colorsensor/deps.bzl
@@ -1,0 +1,7 @@
+load("//dependencies/colorsensor/1_2_0:deps.bzl", "setup_colorsensor_1_2_0_dependencies")
+
+def setup_colorsensor_dependencies(version):
+    if version == "1.2.0":
+        setup_colorsensor_1_2_0_dependencies()
+    else:
+        fail("Unsupported version '{}'".format(version))

--- a/bazelrio/dependencies/navx/4_0_425/deps.bzl
+++ b/bazelrio/dependencies/navx/4_0_425/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
 
-def setup_navx_dependencies():
+def setup_navx_4_0_425_dependencies():
     maybe(
         http_archive,
         "__bazelrio_com_kauailabs_navx_frc_navx-cpp_headers",

--- a/bazelrio/dependencies/navx/deps.bzl
+++ b/bazelrio/dependencies/navx/deps.bzl
@@ -1,0 +1,7 @@
+load("//dependencies/navx/4_0_425:deps.bzl", "setup_navx_4_0_425_dependencies")
+
+def setup_navx_dependencies(version):
+    if version == "4.0.425":
+        setup_navx_4_0_425_dependencies()
+    else:
+        fail("Unsupported version '{}'".format(version))

--- a/bazelrio/dependencies/ni/2020_9_2/deps.bzl
+++ b/bazelrio/dependencies/ni/2020_9_2/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_shared")
 
-def setup_ni_dependencies():
+def setup_ni_2020_9_2_dependencies():
     maybe(
         http_archive,
         "__bazelrio_edu_wpi_first_ni-libraries_chipobject_linuxathena",

--- a/bazelrio/dependencies/ni/deps.bzl
+++ b/bazelrio/dependencies/ni/deps.bzl
@@ -1,0 +1,7 @@
+load("//dependencies/ni/2020_9_2:deps.bzl", "setup_ni_2020_9_2_dependencies")
+
+def setup_ni_dependencies(version):
+    if version == "2020.9.2":
+        setup_ni_2020_9_2_dependencies()
+    else:
+        fail("Unsupported version '{}'".format(version))

--- a/bazelrio/dependencies/phoenix/5_19_4/deps.bzl
+++ b/bazelrio/dependencies/phoenix/5_19_4/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
 
-def setup_phoenix_dependencies():
+def setup_phoenix_5_19_4_dependencies():
     maybe(
         http_archive,
         "__bazelrio_com_ctre_phoenix_api-cpp_headers",

--- a/bazelrio/dependencies/phoenix/deps.bzl
+++ b/bazelrio/dependencies/phoenix/deps.bzl
@@ -1,0 +1,7 @@
+load("//dependencies/phoenix/5_19_4:deps.bzl", "setup_phoenix_5_19_4_dependencies")
+
+def setup_phoenix_dependencies(version):
+    if version == "5.19.4":
+        setup_phoenix_5_19_4_dependencies()
+    else:
+        fail("Unsupported version '{}'".format(version))

--- a/bazelrio/dependencies/sparkmax/1_5_4/deps.bzl
+++ b/bazelrio/dependencies/sparkmax/1_5_4/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
 
-def setup_sparkmax_dependencies():
+def setup_sparkmax_1_5_4_dependencies():
     maybe(
         http_archive,
         "__bazelrio_com_revrobotics_frc_sparkmax-cpp_headers",

--- a/bazelrio/dependencies/sparkmax/deps.bzl
+++ b/bazelrio/dependencies/sparkmax/deps.bzl
@@ -1,0 +1,7 @@
+load("//dependencies/sparkmax/1_5_4:deps.bzl", "setup_sparkmax_1_5_4_dependencies")
+
+def setup_sparkmax_dependencies(version):
+    if version == "1.5.4":
+        setup_sparkmax_1_5_4_dependencies()
+    else:
+        fail("Unsupported version '{}'".format(version))

--- a/bazelrio/dependencies/wpilib/2021_3_1/deps.bzl
+++ b/bazelrio/dependencies/wpilib/2021_3_1/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
 
-def setup_wpilib_dependencies():
+def setup_wpilib_2021_3_1_dependencies():
     maybe(
         http_archive,
         "__bazelrio_edu_wpi_first_wpilibc_linuxathena",

--- a/bazelrio/dependencies/wpilib/deps.bzl
+++ b/bazelrio/dependencies/wpilib/deps.bzl
@@ -1,0 +1,7 @@
+load("//dependencies/wpilib/2021_3_1:deps.bzl", "setup_wpilib_2021_3_1_dependencies")
+
+def setup_wpilib_dependencies(version):
+    if version == "2021.3.1":
+        setup_wpilib_2021_3_1_dependencies()
+    else:
+        fail("Unsupported version '{}'".format(version))

--- a/bazelrio/deps.bzl
+++ b/bazelrio/deps.bzl
@@ -1,14 +1,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-# THE FOLLOWING LINES ARE AUTOMATICALLY GENERATED. DO NOT WRITE BELOW THIS LINE!load(//dependencies/wpilib/2021/3/1/:deps.bzl, setup_wpilib_dependencies)
-load("//dependencies/wpilib/2021_3_1:deps.bzl", "setup_wpilib_dependencies")
-load("//dependencies/ni/2020_9_2:deps.bzl", "setup_ni_dependencies")
-load("//dependencies/sparkmax/1_5_4:deps.bzl", "setup_sparkmax_dependencies")
-load("//dependencies/colorsensor/1_2_0:deps.bzl", "setup_colorsensor_dependencies")
-load("//dependencies/phoenix/5_19_4:deps.bzl", "setup_phoenix_dependencies")
-load("//dependencies/navx/4_0_425:deps.bzl", "setup_navx_dependencies")
-# THE FOLLOWING LINES ARE AUTOMATICALLY GENERATED. DO NOT WRITE ABOVE THIS LINE!
+load("//dependencies/wpilib:deps.bzl", "setup_wpilib_dependencies")
+load("//dependencies/ni:deps.bzl", "setup_ni_dependencies")
+load("//dependencies/sparkmax:deps.bzl", "setup_sparkmax_dependencies")
+load("//dependencies/colorsensor:deps.bzl", "setup_colorsensor_dependencies")
+load("//dependencies/phoenix:deps.bzl", "setup_phoenix_dependencies")
+load("//dependencies/navx:deps.bzl", "setup_navx_dependencies")
 
 filegroup_all = """filegroup(
     name = "all",
@@ -25,7 +22,13 @@ cc_library_headers = """cc_library(
 )
 """
 
-def setup_bazelrio_dependencies():
+def setup_bazelrio_dependencies(
+        wpilib_version = "2021.3.1",
+        ni_version = "2020.9.2",
+        sparkmax_version = "1.5.4",
+        colorsensor_version = "1.2.0",
+        phoenix_version = "5.19.4",
+        navx_version = "4.0.425"):
     # Other bazel rules
     maybe(
         http_archive,
@@ -57,11 +60,9 @@ def setup_bazelrio_dependencies():
         build_file_content = filegroup_all,
     )
 
-    # THE FOLLOWING LINES ARE AUTOMATICALLY GENERATED. DO NOT WRITE BELOW THIS LINE!setup_wpilib_dependencies()
-    setup_wpilib_dependencies()
-    setup_ni_dependencies()
-    setup_sparkmax_dependencies()
-    setup_colorsensor_dependencies()
-    setup_phoenix_dependencies()
-    setup_navx_dependencies()
-    # THE FOLLOWING LINES ARE AUTOMATICALLY GENERATED. DO NOT WRITE ABOVE THIS LINE!
+    setup_wpilib_dependencies(version = wpilib_version)
+    setup_ni_dependencies(version = ni_version)
+    setup_sparkmax_dependencies(version = sparkmax_version)
+    setup_colorsensor_dependencies(version = colorsensor_version)
+    setup_phoenix_dependencies(version = phoenix_version)
+    setup_navx_dependencies(version = navx_version)


### PR DESCRIPTION
As new versions will be coming out (and likely coming out during the season), this gives us the ability for the user to specify exact versions in their workspace. This will help if they want to update their wpilib version, but lock their ctre version.

This doesn't include the generation updates, since I'm about to refactor that to allow multiple versions as well.