### PR TITLE
Modifying the README action to only run on tags

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -16,8 +16,10 @@ jobs:
                 git config --global user.email 'connorworley@users.noreply.github.com'
                 git add README.md
                 git commit -m 'Update README http_archive'
+            - name: Set title name
+              run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v3
               with:
                 base: main
-                title: Update README for tag ${GITHUB_REF#refs/*/}
+                title: Update README for tag ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Should make the main builds green again. See #48 for an example of what happens on a tag/release.

Sorry for the spam you probably got while I was debugging