### PR TITLE
[deploy] Crawl for dynamic library dependencies and copy them to the roborio

### DIFF
--- a/.github/workflows/build-example.yaml
+++ b/.github/workflows/build-example.yaml
@@ -10,14 +10,8 @@ jobs:
             - name: Build Roborio
               run: bazel build //...:* --config=roborio --experimental_use_sandboxfs
               working-directory: examples/cpp_example
-            - name: TEMP FAKE DEPLOY
-              run: bazel run //:robot.deploy --config=roborio --experimental_use_sandboxfs
-              working-directory: examples/cpp_example
             - name: Build Native
               run: bazel build //...:* --config=osx --experimental_use_sandboxfs
-              working-directory: examples/cpp_example
-            - name: TEMP FAKE DEPLOY
-              run: bazel run //:robot.deploy --config=osx --experimental_use_sandboxfs
               working-directory: examples/cpp_example
     build-linux:
         runs-on: ubuntu-latest
@@ -28,14 +22,8 @@ jobs:
             - name: Build Roborio
               run: bazel build //...:* --config=roborio --experimental_use_sandboxfs
               working-directory: examples/cpp_example
-            - name: TEMP FAKE DEPLOY
-              run: bazel run //:robot.deploy --config=roborio --experimental_use_sandboxfs
-              working-directory: examples/cpp_example
             - name: Build Native
               run: bazel build //...:* --config=linux --experimental_use_sandboxfs
-              working-directory: examples/cpp_example
-            - name: TEMP FAKE DEPLOY
-              run: bazel run //:robot.deploy --config=linux --experimental_use_sandboxfs
               working-directory: examples/cpp_example
     build-windows:
         runs-on: windows-latest
@@ -44,12 +32,6 @@ jobs:
             - name: Build Roborio
               run: bazel --output_user_root=C:\bazelroot build //...:* --config=roborio
               working-directory: examples/cpp_example
-            - name: TEMP FAKE DEPLOY
-              run: bazel --output_user_root=C:\bazelroot run //:robot.deploy --config=roborio
-              working-directory: examples/cpp_example
             - name: Build Native
               run: bazel --output_user_root=C:\bazelroot build //...:* --config=windows
-              working-directory: examples/cpp_example
-            - name: TEMP FAKE DEPLOY
-              run: bazel --output_user_root=C:\bazelroot run //:robot.deploy --config=windows
               working-directory: examples/cpp_example

--- a/.github/workflows/build-example.yaml
+++ b/.github/workflows/build-example.yaml
@@ -10,8 +10,14 @@ jobs:
             - name: Build Roborio
               run: bazel build //...:* --config=roborio --experimental_use_sandboxfs
               working-directory: examples/cpp_example
+            - name: TEMP FAKE DEPLOY
+              run: bazel run //:robot.deploy --config=roborio --experimental_use_sandboxfs
+              working-directory: examples/cpp_example
             - name: Build Native
               run: bazel build //...:* --config=osx --experimental_use_sandboxfs
+              working-directory: examples/cpp_example
+            - name: TEMP FAKE DEPLOY
+              run: bazel run //:robot.deploy --config=osx --experimental_use_sandboxfs
               working-directory: examples/cpp_example
     build-linux:
         runs-on: ubuntu-latest
@@ -22,8 +28,14 @@ jobs:
             - name: Build Roborio
               run: bazel build //...:* --config=roborio --experimental_use_sandboxfs
               working-directory: examples/cpp_example
+            - name: TEMP FAKE DEPLOY
+              run: bazel run //:robot.deploy --config=roborio --experimental_use_sandboxfs
+              working-directory: examples/cpp_example
             - name: Build Native
               run: bazel build //...:* --config=linux --experimental_use_sandboxfs
+              working-directory: examples/cpp_example
+            - name: TEMP FAKE DEPLOY
+              run: bazel run //:robot.deploy --config=linux --experimental_use_sandboxfs
               working-directory: examples/cpp_example
     build-windows:
         runs-on: windows-latest
@@ -32,6 +44,12 @@ jobs:
             - name: Build Roborio
               run: bazel --output_user_root=C:\bazelroot build //...:* --config=roborio
               working-directory: examples/cpp_example
+            - name: TEMP FAKE DEPLOY
+              run: bazel --output_user_root=C:\bazelroot run //:robot.deploy --config=roborio
+              working-directory: examples/cpp_example
             - name: Build Native
               run: bazel --output_user_root=C:\bazelroot build //...:* --config=windows
+              working-directory: examples/cpp_example
+            - name: TEMP FAKE DEPLOY
+              run: bazel --output_user_root=C:\bazelroot run //:robot.deploy --config=windows
               working-directory: examples/cpp_example

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -2,10 +2,10 @@ import argparse
 import sys
 from os.path import basename
 
-# from blessings import Terminal
+from blessings import Terminal
 from paramiko.client import MissingHostKeyPolicy, SSHClient
 
-# term = Terminal()
+term = Terminal()
 
 class SilentAllowPolicy(MissingHostKeyPolicy):
     def missing_host_key(self, client, hostname, key):
@@ -55,15 +55,6 @@ def deploy(argv):
     parser.add_argument("--dynamic_libraries", nargs='*')
     args = parser.parse_args(argv)
 
-    import os
-    import sys
-    print(args.robot_binary)
-    for dynamic in args.dynamic_libraries:
-        print(os.path.exists(dynamic), dynamic)
-        if not os.path.exists(dynamic):
-            sys.exit(-1)
-    return
-
     client = establish_connection(args.team_number, args.verbose)
 
     print(term.bright_yellow(f"Attempting to deploy {args.robot_binary.name}..."))
@@ -84,6 +75,9 @@ def deploy(argv):
     sftp_client.chmod("/home/lvuser/robotCommand", 0o755)
     sftp_client.chown(destination_path, 500, 500)
     sftp_client.chown("/home/lvuser/robotCommand", 500, 500)
+    for dylib_path in args.dynamic_libraries:
+        dylib_name = basename(dylib_path)
+        sftp_client.put(dylib_path, f"/usr/local/frc/third-party//{dylib_name}")
     client.exec_command(f"setcap cap_sys_nice+eip '{destination_path}'")
     client.exec_command("sync")
     client.exec_command("ldconfig")

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -2,10 +2,10 @@ import argparse
 import sys
 from os.path import basename
 
-from blessings import Terminal
+# from blessings import Terminal
 from paramiko.client import MissingHostKeyPolicy, SSHClient
 
-term = Terminal()
+# term = Terminal()
 
 class SilentAllowPolicy(MissingHostKeyPolicy):
     def missing_host_key(self, client, hostname, key):
@@ -52,7 +52,17 @@ def deploy(argv):
     parser.add_argument("--robot_binary", type=argparse.FileType(mode="rb"), required=True)
     parser.add_argument("--team_number", type=int, required=True)
     parser.add_argument("--verbose", action="store_true", default=False)
+    parser.add_argument("--dynamic_libraries", nargs='*')
     args = parser.parse_args(argv)
+
+    import os
+    import sys
+    print(args.robot_binary)
+    for dynamic in args.dynamic_libraries:
+        print(os.path.exists(dynamic), dynamic)
+        if not os.path.exists(dynamic):
+            sys.exit(-1)
+    return
 
     client = establish_connection(args.team_number, args.verbose)
 

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -77,7 +77,7 @@ def deploy(argv):
     sftp_client.chown("/home/lvuser/robotCommand", 500, 500)
     for dylib_path in args.dynamic_libraries:
         dylib_name = basename(dylib_path)
-        sftp_client.put(dylib_path, f"/usr/local/frc/third-party//{dylib_name}")
+        sftp_client.put(dylib_path, f"/usr/local/frc/third-party/{dylib_name}")
     client.exec_command(f"setcap cap_sys_nice+eip '{destination_path}'")
     client.exec_command("sync")
     client.exec_command("ldconfig")

--- a/bazelrio/toolchains/roborio/BUILD
+++ b/bazelrio/toolchains/roborio/BUILD
@@ -6,9 +6,11 @@ cc_toolchain_config(
         "@bazel_tools//src/conditions:darwin_x86_64": "macos",
         "@bazel_tools//src/conditions:linux_x86_64": "linux",
         "@bazel_tools//src/conditions:windows": "windows",
+        "//conditions:default": "unknown",
     }),
     script_suffix = select({
         "@bazel_tools//src/conditions:windows": ".bat",
+        "@bazel_tools//src/conditions:host_windows": ".bat",
         "//conditions:default": "",
     }),
 )


### PR DESCRIPTION
Leaves Bazel at 4.2.1, but gives example how to crawl for dynamic libs need to copy over.

Since I don't have a roborio, it just prints out that the files do in fact exist.