### PR TITLE
Fix windows builds

### DIFF
--- a/.github/workflows/build-example.yaml
+++ b/.github/workflows/build-example.yaml
@@ -30,8 +30,8 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Build Roborio
-              run: bazel --output_user_root=C:\bazelroot build //...:* --config=roborio
+              run: bazel --output_user_root=C:\bazelroot build //...:* --features=compiler_param_file --config=roborio
               working-directory: examples/cpp_example
             - name: Build Native
-              run: bazel --output_user_root=C:\bazelroot build //...:* --config=windows
+              run: bazel --output_user_root=C:\bazelroot build //...:* --features=compiler_param_file --config=windows
               working-directory: examples/cpp_example

--- a/.github/workflows/build-example.yaml
+++ b/.github/workflows/build-example.yaml
@@ -8,10 +8,10 @@ jobs:
             - run: brew install osxfuse
             - run: curl -sSL https://github.com/bazelbuild/sandboxfs/releases/download/sandboxfs-0.2.0/sandboxfs-0.2.0-20200420-macos.pkg -o sandboxfs.pkg && sudo installer -pkg sandboxfs.pkg -target /
             - name: Build Roborio
-              run: bazel build //...:* --config=roborio --experimental_use_sandboxfs
+              run: bazel build //...:* --config=for-roborio --experimental_use_sandboxfs
               working-directory: examples/cpp_example
             - name: Build Native
-              run: bazel build //...:* --config=osx --experimental_use_sandboxfs
+              run: bazel build //...:* --experimental_use_sandboxfs
               working-directory: examples/cpp_example
     build-linux:
         runs-on: ubuntu-latest
@@ -20,18 +20,18 @@ jobs:
             - run: sudo apt-get install libfuse-dev
             - run: curl -sSL https://github.com/bazelbuild/sandboxfs/releases/download/sandboxfs-0.2.0/sandboxfs-0.2.0-20200420-linux-x86_64.tgz | sudo tar zxv -C /usr/local -f -
             - name: Build Roborio
-              run: bazel build //...:* --config=roborio --experimental_use_sandboxfs
+              run: bazel build //...:* --config=for-roborio --experimental_use_sandboxfs
               working-directory: examples/cpp_example
             - name: Build Native
-              run: bazel build //...:* --config=linux --experimental_use_sandboxfs
+              run: bazel build //...:* --experimental_use_sandboxfs
               working-directory: examples/cpp_example
     build-windows:
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v2
             - name: Build Roborio
-              run: bazel --output_user_root=C:\bazelroot build //...:* --features=compiler_param_file --config=roborio
+              run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-roborio
               working-directory: examples/cpp_example
             - name: Build Native
-              run: bazel --output_user_root=C:\bazelroot build //...:* --features=compiler_param_file --config=windows
+              run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-windows
               working-directory: examples/cpp_example

--- a/bazelrio/toolchains/roborio/toolchain_config.bzl
+++ b/bazelrio/toolchains/roborio/toolchain_config.bzl
@@ -82,8 +82,8 @@ def _impl(ctx):
                 ],
             ),
             feature(
-                name = "compiler_param_file"
-            )
+                name = "compiler_param_file",
+            ),
         ],
     )
 

--- a/bazelrio/toolchains/roborio/toolchain_config.bzl
+++ b/bazelrio/toolchains/roborio/toolchain_config.bzl
@@ -81,6 +81,9 @@ def _impl(ctx):
                     ),
                 ],
             ),
+            feature(
+                name = "compiler_param_file"
+            )
         ],
     )
 

--- a/examples/cpp_example/.bazelrc
+++ b/examples/cpp_example/.bazelrc
@@ -1,6 +1,7 @@
 try-import user.bazelrc
 
 build --incompatible_enable_cc_toolchain_resolution
+build --enable_platform_specific_config
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.
 # build --experimental_use_sandboxfs
@@ -8,17 +9,21 @@ build --incompatible_enable_cc_toolchain_resolution
 # Uncomment me on Windows if you have spaces in your default output_user_root (very likely).
 # startup --output_user_root=C:\\bazelroot
 
-
-# Roborio
-build:roborio --platforms=@bazelrio//platforms/roborio
-
 # Windows
-build:windows --copt=/std:c++17
+build:windows --features=compiler_param_file
+build:windows --experimental_repository_cache C:\\bazelcache
 
 # Linux
 build:linux --copt=-std=c++17
 build:linux --linkopt=-pthread
+build:linux --experimental_repository_cache ~/.local/share/bazel
 
-# OSX
-build:osx --copt=-std=c++17
+# MacOS
+build:macos --copt=-std=c++17
+build:macos --experimental_repository_cache ~/.local/share/bazel
 
+# For Roborio
+build:for-roborio --platforms=@bazelrio//platforms/roborio
+
+# For Windows
+build:for-windows --copt=/std:c++17

--- a/examples/cpp_example/src/commands/BUILD
+++ b/examples/cpp_example/src/commands/BUILD
@@ -5,8 +5,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/subsystems",
-        "@bazelrio//libraries/cpp/ctre/phoenix",
-        "@bazelrio//libraries/cpp/rev/sparkmax",
         "@bazelrio//libraries/cpp/wpilib/new_commands",
         "@bazelrio//libraries/cpp/wpilib/wpilibc",
     ],

--- a/examples/cpp_example/src/commands/BUILD
+++ b/examples/cpp_example/src/commands/BUILD
@@ -5,9 +5,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/subsystems",
-        "@bazelrio//libraries/cpp/wpilib/new_commands",
-        "@bazelrio//libraries/cpp/wpilib/wpilibc",
         "@bazelrio//libraries/cpp/ctre/phoenix",
         "@bazelrio//libraries/cpp/rev/sparkmax",
+        "@bazelrio//libraries/cpp/wpilib/new_commands",
+        "@bazelrio//libraries/cpp/wpilib/wpilibc",
     ],
 )

--- a/examples/cpp_example/src/commands/BUILD
+++ b/examples/cpp_example/src/commands/BUILD
@@ -7,5 +7,7 @@ cc_library(
         "//src/subsystems",
         "@bazelrio//libraries/cpp/wpilib/new_commands",
         "@bazelrio//libraries/cpp/wpilib/wpilibc",
+        "@bazelrio//libraries/cpp/ctre/phoenix",
+        "@bazelrio//libraries/cpp/rev/sparkmax",
     ],
 )


### PR DESCRIPTION
This adds the compiler_param_file feature to the cross-compiler which fixes Windows builds using all of the libraries.

Unfortunately I am stuck on this error now.

I will probably also redo the .bazelrc in this PR

Closes #37.
Closes #19.