### PR TITLE
Add LD_LIBRARY_PATH to robotCommand, deploy progress bars, and hash checks

### DIFF
--- a/bazelrio/scripts/deploy/BUILD
+++ b/bazelrio/scripts/deploy/BUILD
@@ -6,6 +6,7 @@ py_binary(
     srcs = ["deploy.py"],
     visibility = ["//visibility:public"],
     deps = [
+        requirement("alive-progress"),
         requirement("blessings"),
         requirement("paramiko"),
     ],

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -154,7 +154,7 @@ def deploy(argv):
         try:
             sftp_client.mkdir(DYLIB_DIR)
         except IOError as e:
-            if verbose:
+            if args.verbose:
                 print(e)
         for dylib_path in args.dynamic_libraries:
             dylib_name = basename(dylib_path)

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -143,7 +143,7 @@ def deploy(argv):
             # describe how their binaries should be executed on the rio.
             # the remote location of the robot binary is substituted into the format string, and the whole thing is
             # wrapped in a bash command that sets -x before execing into the formatted string.
-            # this is done as a convenience so that the user can see exactly what is running in FRC_UserProgram.log/
+            # this is done as a convenience so that the user can see exactly what is running in FRC_UserProgram.log.
             inner_robot_command = args.robot_command.format(quoted_destination_path)
             bash_command = f"set -euxo pipefail; exec {inner_robot_command}"
             fo.write(f"bash -c {quote(bash_command)}\n")
@@ -153,8 +153,9 @@ def deploy(argv):
         # copy shared libraries
         try:
             sftp_client.mkdir(DYLIB_DIR)
-        except IOError:
-            pass
+        except IOError as e:
+            if verbose:
+                print(e)
         for dylib_path in args.dynamic_libraries:
             dylib_name = basename(dylib_path)
             progress_bar.text(dylib_name)

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -3,10 +3,17 @@ import hashlib
 import os
 import sys
 from os.path import basename
+from shlex import quote
 
 from alive_progress import alive_bar
 from blessings import Terminal
 from paramiko.client import MissingHostKeyPolicy, SSHClient
+
+DEPLOYED_FILE_PERMS = 0o755
+DYLIB_DIR = "/usr/local/frc/third-party/lib/"
+LVUSER_UID = 500
+LVUSER_GID = 500
+ROBOTCOMAND_PATH = "/home/lvuser/robotCommand"
 
 term = Terminal()
 
@@ -16,6 +23,7 @@ class SilentAllowPolicy(MissingHostKeyPolicy):
 
 
 def establish_connection(team_number, verbose):
+    # addresses supplied from
     # https://github.com/wpilibsuite/GradleRIO/blob/aaf4da44e914a49e0bb956b028130481f538b31c/src/main/groovy/edu/wpi/first/gradlerio/frc/RoboRIO.groovy#L40
     addresses = [
         f"roborio-{team_number}-frc.local",
@@ -50,69 +58,116 @@ def establish_connection(team_number, verbose):
     sys.exit(1)
 
 
-def transfer_file(ssh_client, sftp_client, local_path, remote_path):
-    with open(local_path, "rb") as local_fo:
-        local_size = os.fstat(local_fo.fileno()).st_size
+def transfer_file(ssh_client, sftp_client, local_fo, remote_path, verbose):
+    local_size = os.fstat(local_fo.fileno()).st_size
 
-        try:
-            remote_fo = sftp_client.open(remote_path)
-            if remote_fo.stat().st_size == local_size:
-                _, remote_hash_stdout_fo, _ = ssh_client.exec_command(f"md5sum {remote_path}")
-                remote_hash = remote_hash_stdout_fo.read().split()[0].decode()
-                local_hash = hashlib.md5(local_fo.read()).hexdigest()
+    if verbose:
+        print(f"checking {remote_path}")
 
-                if remote_hash == local_hash:
-                    print(f"{basename(local_path)} already exists on remote host")
-                    return
-        except IOError as e:
-            pass
+    try:
+        remote_fo = sftp_client.open(remote_path)
+        remote_size = remote_fo.stat().st_size
 
-        with alive_bar(local_size, manual=True, title=basename(local_path), theme="classic") as bar:
-            sftp_client.putfo(local_fo, remote_path, 0, lambda pos, _: bar(pos / local_size))
+        if verbose:
+            print(f"local size: {local_size}, remote size: {remote_size}")
+
+        if remote_size == local_size:
+            local_hash = hashlib.md5(local_fo.read()).hexdigest()
+            _, remote_hash_stdout_fo, _ = ssh_client.exec_command(f"md5sum {quote(remote_path)}")
+            remote_hash = remote_hash_stdout_fo.read().split()[0].decode()
+
+            if verbose:
+                print(f"local hash: {local_hash}, remote hash: {remote_hash}")
+
+            if remote_hash == local_hash:
+                return
+    except Exception as e:
+        # could fail due to misisng file, misisng md5sum, etc.
+        if verbose:
+            print(e)
+        pass
+
+    if verbose:
+        print(f"copying {local_fo.name} -> {remote_path}")
+
+    sftp_client.putfo(local_fo, remote_path)
 
 
 def deploy(argv):
     parser = argparse.ArgumentParser(description="Deploy code to a roboRIO")
     parser.add_argument("--robot_binary", type=argparse.FileType(mode="rb"), required=True)
+    parser.add_argument("--robot_command", type=str, default="{}")
     parser.add_argument("--team_number", type=int, required=True)
     parser.add_argument("--verbose", action="store_true", default=False)
     parser.add_argument("--dynamic_libraries", nargs='*')
     args = parser.parse_args(argv)
 
-    client = establish_connection(args.team_number, args.verbose)
+    with alive_bar(
+            len(args.dynamic_libraries) + 1,
+            enrich_print=False,
+            monitor=False,
+            stats=False,
+            theme="classic",
+    ) as progress_bar:
+        client = establish_connection(args.team_number, args.verbose)
+        sftp_client = client.open_sftp()
 
-    print(term.bright_yellow(f"Attempting to deploy {args.robot_binary.name}..."))
+        binary_name = basename(args.robot_binary.name)
+        destination_path = f"/home/lvuser/{binary_name}"
+        quoted_destination_path = quote(destination_path)
 
-    sftp_client = client.open_sftp()
-    binary_name = basename(args.robot_binary.name)
-    destination_path = f"/home/lvuser/{binary_name}"
-    # https://github.com/wpilibsuite/GradleRIO/blob/aaf4da44e914a49e0bb956b028130481f538b31c/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCNativeArtifact.groovy#L29
-    client.exec_command(". /etc/profile.d/natinst-path.sh; /usr/local/frc/bin/frcKillRobot.sh -t")
-    try:
-        sftp_client.remove(destination_path)
-    except FileNotFoundError:
-        print(term.bright_white("Previous robot executable not found so not deleted."))
-    transfer_file(client, sftp_client, args.robot_binary.name, destination_path)
-    sftp_client.chmod(destination_path, 0o755)
-    with sftp_client.open("/home/lvuser/robotCommand", "w") as f:
-        f.write(f"'{destination_path}'\n")
-    sftp_client.chmod("/home/lvuser/robotCommand", 0o755)
-    sftp_client.chown(destination_path, 500, 500)
-    sftp_client.chown("/home/lvuser/robotCommand", 500, 500)
-    try:
-        sftp_client.mkdir("/usr/local/frc/third-party/lib/")
-    except IOError:
-        pass
-    for dylib_path in args.dynamic_libraries:
-        dylib_name = basename(dylib_path)
-        transfer_file(client, sftp_client, dylib_path, f"/usr/local/frc/third-party/lib/{dylib_name}")
+        print(term.bright_yellow(f"Attempting to deploy {binary_name}..."))
 
-    client.exec_command(f"setcap cap_sys_nice+eip '{destination_path}'")
-    client.exec_command("sync")
-    client.exec_command("ldconfig")
-    client.exec_command(". /etc/profile.d/natinst-path.sh; /usr/local/frc/bin/frcKillRobot.sh -t -r")
+        # deploy process adapted from
+        # https://github.com/wpilibsuite/GradleRIO/blob/aaf4da44e914a49e0bb956b028130481f538b31c/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCNativeArtifact.groovy#L29
 
-    print(term.bright_green(f"Deployed {args.robot_binary.name}. Exiting."))
+        # stop and remove existing robot binary
+        client.exec_command(". /etc/profile.d/natinst-path.sh; /usr/local/frc/bin/frcKillRobot.sh -t")
+        try:
+            sftp_client.remove(destination_path)
+        except FileNotFoundError as e:
+            if args.verbose:
+                print(e)
+
+        # copy new robot binary
+        progress_bar.text(binary_name)
+        transfer_file(client, sftp_client,args.robot_binary, destination_path, args.verbose)
+        sftp_client.chmod(destination_path, DEPLOYED_FILE_PERMS)
+        sftp_client.chown(destination_path, LVUSER_UID, LVUSER_GID)
+        client.exec_command(f"setcap cap_sys_nice+eip {quoted_destination_path}")
+        progress_bar()
+
+        # write new robotCommand
+        with sftp_client.open("/home/lvuser/robotCommand", "w") as fo:
+            # we take a robotCommand format string as a argument to make it easier for different languages (ie java) to
+            # describe how their binaries should be executed on the rio.
+            # the remote location of the robot binary is substituted into the format string, and the whole thing is
+            # wrapped in a bash command that sets -x before execing into the formatted string.
+            # this is done as a convenience so that the user can see exactly what is running in FRC_UserProgram.log/
+            inner_robot_command = args.robot_command.format(quoted_destination_path)
+            bash_command = f"set -euxo pipefail; exec {inner_robot_command}"
+            fo.write(f"bash -c {quote(bash_command)}\n")
+        sftp_client.chmod(ROBOTCOMAND_PATH, DEPLOYED_FILE_PERMS)
+        sftp_client.chown(ROBOTCOMAND_PATH, LVUSER_UID, LVUSER_GID)
+
+        # copy shared libraries
+        try:
+            sftp_client.mkdir(DYLIB_DIR)
+        except IOError:
+            pass
+        for dylib_path in args.dynamic_libraries:
+            dylib_name = basename(dylib_path)
+            progress_bar.text(dylib_name)
+            with open(dylib_path, "rb") as dylib_fo:
+                transfer_file(client, sftp_client, dylib_fo, f"{DYLIB_DIR}{dylib_name}", args.verbose)
+            progress_bar()
+
+        # restart robot code
+        client.exec_command("sync")
+        client.exec_command("ldconfig")
+        client.exec_command(". /etc/profile.d/natinst-path.sh; /usr/local/frc/bin/frcKillRobot.sh -t -r")
+
+        print(term.bright_green(f"Deployed {binary_name}. Exiting."))
 
 
 if __name__ == "__main__":

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -95,13 +95,18 @@ def deploy(argv):
     transfer_file(client, sftp_client, args.robot_binary.name, destination_path)
     sftp_client.chmod(destination_path, 0o755)
     with sftp_client.open("/home/lvuser/robotCommand", "w") as f:
-        f.write(f"LD_LIBRARY_PATH=/usr/local/frc/third-party/ '{destination_path}'\n")
+        f.write(f"'{destination_path}'\n")
     sftp_client.chmod("/home/lvuser/robotCommand", 0o755)
     sftp_client.chown(destination_path, 500, 500)
     sftp_client.chown("/home/lvuser/robotCommand", 500, 500)
+    try:
+        sftp_client.mkdir("/usr/local/frc/third-party/lib/")
+    except IOError:
+        pass
     for dylib_path in args.dynamic_libraries:
         dylib_name = basename(dylib_path)
-        transfer_file(client, sftp_client, dylib_path, f"/usr/local/frc/third-party/{dylib_name}")
+        transfer_file(client, sftp_client, dylib_path, f"/usr/local/frc/third-party/lib/{dylib_name}")
+
     client.exec_command(f"setcap cap_sys_nice+eip '{destination_path}'")
     client.exec_command("sync")
     client.exec_command("ldconfig")

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -138,7 +138,7 @@ def deploy(argv):
         progress_bar()
 
         # write new robotCommand
-        with sftp_client.open("/home/lvuser/robotCommand", "w") as fo:
+        with sftp_client.open(ROBOTCOMAND_PATH, "w") as fo:
             # we take a robotCommand format string as a argument to make it easier for different languages (ie java) to
             # describe how their binaries should be executed on the rio.
             # the remote location of the robot binary is substituted into the format string, and the whole thing is

--- a/bazelrio/scripts/deploy/requirements.txt
+++ b/bazelrio/scripts/deploy/requirements.txt
@@ -1,7 +1,10 @@
+about-time==3.1.1
+alive-progress==2.1.0
 bcrypt==3.2.0
 blessings==1.7
 cffi==1.14.6
 cryptography==3.4.8
+grapheme==0.6.0
 paramiko==2.7.2
 pycparser==2.20
 PyNaCl==1.4.0


### PR DESCRIPTION
This makes robotCommand work and gives the user some feedback about their deploys. Hashing does improve performance by 2-3 seconds on my machine, with md5 being the fastest algorithm that's easy to get on a rio. We could probably go faster with some rolling crc or alder32 thing, but we would have to install a tool on the rio side to perform it.

first run (empty third-party/):
```
[23:26:29] ~/Code/bazelRio/bazelRio/examples/cpp_example time bazel run :robot.deploy --experimental_use_sandboxfs --platforms=@bazelrio//platforms/roborio
...

________________________________________________________
Executed in    7.99 secs   fish           external
   usr time  1201.71 millis  112.00 micros  1201.60 millis
   sys time  360.84 millis  782.00 micros  360.06 millis
```

second run:
```
[23:26:56] ~/Code/bazelRio/bazelRio/examples/cpp_example time bazel run :robot.deploy --experimental_use_sandboxfs --platforms=@bazelrio//platforms/roborio
...

________________________________________________________
Executed in    5.21 secs   fish           external
   usr time  435.89 millis  123.00 micros  435.76 millis
   sys time  225.19 millis  669.00 micros  224.52 millis
```

progress bars:

https://user-images.githubusercontent.com/1512426/141945547-689ae7fa-6335-4790-9787-8bcf4415bff9.mov



