### PR TITLE
Adding ability to launch the allwpilib tools

### DIFF
--- a/.github/workflows/build-example.yaml
+++ b/.github/workflows/build-example.yaml
@@ -14,10 +14,10 @@ jobs:
               run: bazel build //...:* --experimental_use_sandboxfs
               working-directory: examples/cpp_example
             - name: Build Roborio (java))
-              run: bazel build //...:* --config=for-roborio --experimental_use_sandboxfs --java_runtime_version=remotejdk_11
+              run: bazel build //...:* --config=for-roborio --experimental_use_sandboxfs
               working-directory: examples/java_example
             - name: Build Native (java)
-              run: bazel build //...:* --experimental_use_sandboxfs --java_runtime_version=remotejdk_11
+              run: bazel build //...:* --experimental_use_sandboxfs
               working-directory: examples/java_example
             - name: Build tools
               run: bazel build @bazelrio//libraries/tools/...
@@ -35,10 +35,10 @@ jobs:
               run: bazel build //...:* --experimental_use_sandboxfs
               working-directory: examples/cpp_example
             - name: Build Roborio (java)
-              run: bazel build //...:* --config=for-roborio --experimental_use_sandboxfs --java_runtime_version=remotejdk_11
+              run: bazel build //...:* --config=for-roborio --experimental_use_sandboxfs
               working-directory: examples/java_example
             - name: Build Native (java)
-              run: bazel build //...:* --experimental_use_sandboxfs --java_runtime_version=remotejdk_11
+              run: bazel build //...:* --experimental_use_sandboxfs
               working-directory: examples/java_example
             - name: Build tools
               run: bazel build @bazelrio//libraries/tools/...
@@ -54,10 +54,10 @@ jobs:
               run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-windows
               working-directory: examples/cpp_example
             - name: Build Roborio (java)
-              run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-roborio --java_runtime_version=remotejdk_11
+              run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-roborio
               working-directory: examples/java_example
             - name: Build Native (java)
-              run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-windows --java_runtime_version=remotejdk_11
+              run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-windows
               working-directory: examples/java_example
             - name: Build tools
               run: bazel build @bazelrio//libraries/tools/...

--- a/.github/workflows/build-example.yaml
+++ b/.github/workflows/build-example.yaml
@@ -19,6 +19,9 @@ jobs:
             - name: Build Native (java)
               run: bazel build //...:* --experimental_use_sandboxfs --java_runtime_version=remotejdk_11
               working-directory: examples/java_example
+            - name: Build tools
+              run: bazel build @bazelrio//libraries/tools/...
+              working-directory: examples/java_example
     build-linux:
         runs-on: ubuntu-latest
         steps:
@@ -37,6 +40,9 @@ jobs:
             - name: Build Native (java)
               run: bazel build //...:* --experimental_use_sandboxfs --java_runtime_version=remotejdk_11
               working-directory: examples/java_example
+            - name: Build tools
+              run: bazel build @bazelrio//libraries/tools/...
+              working-directory: examples/java_example
     build-windows:
         runs-on: windows-latest
         steps:
@@ -52,4 +58,7 @@ jobs:
               working-directory: examples/java_example
             - name: Build Native (java)
               run: bazel --output_user_root=C:\bazelroot build //...:* --config=for-windows --java_runtime_version=remotejdk_11
+              working-directory: examples/java_example
+            - name: Build tools
+              run: bazel build @bazelrio//libraries/tools/...
               working-directory: examples/java_example

--- a/bazelrio/dependencies/wpilib/2021_3_1/deps.bzl
+++ b/bazelrio/dependencies/wpilib/2021_3_1/deps.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
@@ -724,4 +724,103 @@ def setup_wpilib_2021_3_1_dependencies():
         artifact = "edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:2021.3.1",
         artifact_sha256 = "fbd0cf5269ef2f265ac1898aed87c075f7ba0ceef2de297c092d7870da8f757d",
         server_urls = ["https://frcmaven.wpi.edu/release"],
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_smartdashboard_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SmartDashboard/2021.3.1/SmartDashboard-2021.3.1-linux64.jar",
+        sha256 = "b885e855f3a7ece1edd3039d777748b88c65142e362afdf758e6c984b51e6538",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_smartdashboard_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SmartDashboard/2021.3.1/SmartDashboard-2021.3.1-mac64.jar",
+        sha256 = "0d339363d212f8e76ea3ef3f85bd2dff06898d738f858c0234298dd09f7365c9",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_smartdashboard_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SmartDashboard/2021.3.1/SmartDashboard-2021.3.1-win64.jar",
+        sha256 = "b4f868f10d4c348d58d5f5ed1c01fb1e35808e16da7a398960f235db43f42ea5",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_pathweaver_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/PathWeaver/2021.3.1/PathWeaver-2021.3.1-linux64.jar",
+        sha256 = "70955d07a4a084aaeaee62f522763c2c5502d4151489343bb7f40f9970a7ced5",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_pathweaver_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/PathWeaver/2021.3.1/PathWeaver-2021.3.1-mac64.jar",
+        sha256 = "df296767ad1d2f628605ec3a1cfc521a5918c283bfe696f179334779d77b97bd",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_pathweaver_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/PathWeaver/2021.3.1/PathWeaver-2021.3.1-win64.jar",
+        sha256 = "c5d94daa925e589501a8060682f2e732ec685020812b9c73dd817057446552d1",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_robotbuilder",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/RobotBuilder/2021.3.1/RobotBuilder-2021.3.1.jar",
+        sha256 = "b8209714298037dd52c89d63eafb9deb547f834e78bd05d72a4933b920312d3f",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/shuffleboard/shuffleboard/2021.3.1/shuffleboard-2021.3.1-linux64.jar",
+        sha256 = "705ed0e31a207e2b764a4ba597dcefc1073a11fe85df0bd97c56849f5e8ee7a8",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/shuffleboard/shuffleboard/2021.3.1/shuffleboard-2021.3.1-mac64.jar",
+        sha256 = "f329a2d9f0ba1ca7cacc9103a48f549eee53ec6fbd8fd970769ad8d535ac5bf9",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/shuffleboard/shuffleboard/2021.3.1/shuffleboard-2021.3.1-win64.jar",
+        sha256 = "bff617803c0ae78bebdaccf0ccfdf0761b1e077952469307bc73011e394ac8c2",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_outlineviewer_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/OutlineViewer/2021.3.1/OutlineViewer-2021.3.1-linux64.jar",
+        sha256 = "7954ea574d765fbbee52d69f6dfca27285c53b95cc9fd88e43000a398b07eeb4",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_outlineviewer_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/OutlineViewer/2021.3.1/OutlineViewer-2021.3.1-mac64.jar",
+        sha256 = "deead63d1a8fcc8c024dbc682056929da5b729981bbbbe620d03b1ea997f3e63",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_outlineviewer_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/OutlineViewer/2021.3.1/OutlineViewer-2021.3.1-win64.jar",
+        sha256 = "cc4299a4369acf03670c8d7785ee89a42f45532b69a679c6fe66f518207628ca",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_glass_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/Glass/2021.3.1/Glass-2021.3.1-windowsx86-64.zip",
+        sha256 = "5ed54addfecccbd5fa1d190b15ad6fc7c29d34d3084201f5390c676d6352102e",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_glass_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/Glass/2021.3.1/Glass-2021.3.1-linuxx86-64.zip",
+        sha256 = "7d4fb06ee9ee5b0479f940dd01268a04667cb176aeec15183042fa404f8efc1d",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_glass_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/Glass/2021.3.1/Glass-2021.3.1-osxx86-64.zip",
+        sha256 = "b111497f49f8cef4f2189ecf34e5dc08f9558fbaa197c5ea7b6f842fe00e6d71",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
     )

--- a/bazelrio/dependencies/wpilib/2022_1_1_beta_1/deps.bzl
+++ b/bazelrio/dependencies/wpilib/2022_1_1_beta_1/deps.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
@@ -724,4 +724,127 @@ def setup_wpilib_2022_1_1_beta_1_dependencies():
         artifact = "edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:2022.1.1-beta-1",
         artifact_sha256 = "3842455781a71aa340468163e911b166573e966c7d5fbfd46e8091909b96e326",
         server_urls = ["https://frcmaven.wpi.edu/release"],
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_smartdashboard_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SmartDashboard/2022.1.1-beta-1/SmartDashboard-2022.1.1-beta-1-linux64.jar",
+        sha256 = "fb421832c106f6f9ebe1f33e196245f045da3d98492b3a68cabc93c16099e330",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_smartdashboard_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SmartDashboard/2022.1.1-beta-1/SmartDashboard-2022.1.1-beta-1-mac64.jar",
+        sha256 = "55d6f7981c28e41a79f081918184ad3f238ae99364fc7761de66a122bd32ee47",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_smartdashboard_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SmartDashboard/2022.1.1-beta-1/SmartDashboard-2022.1.1-beta-1-win64.jar",
+        sha256 = "afc725e395bb97d71e12ee89aeac22bd3f5afec724e69f24dedd2e8fc8e6622b",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_pathweaver_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/PathWeaver/2022.1.1-beta-1/PathWeaver-2022.1.1-beta-1-linux64.jar",
+        sha256 = "e28f067e874772780ce6760b1376a78112cc021ec1eef906e55fe98881fe0d29",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_pathweaver_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/PathWeaver/2022.1.1-beta-1/PathWeaver-2022.1.1-beta-1-mac64.jar",
+        sha256 = "33dda4aee5c592ce56504875628553b0c1a69ef3fc6bb51ecff111a363866cda",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_pathweaver_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/PathWeaver/2022.1.1-beta-1/PathWeaver-2022.1.1-beta-1-win64.jar",
+        sha256 = "6a5058800532570a027de9c70f686223880296974820b736a09889755f9fecc7",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_tools_robotbuilder",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/RobotBuilder/2022.1.1-beta-1/RobotBuilder-2022.1.1-beta-1.jar",
+        sha256 = "d431daca5c2c24ddd0a147826b13fb0dfdfc89f3862b9bbda60d0bdecd188e0a",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard_linux64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/shuffleboard/shuffleboard/2022.1.1-beta-1/shuffleboard-2022.1.1-beta-1-linux64.jar",
+        sha256 = "4c2862156bf207c87d5463b54a5745383086712903eb8c0b53b5fa268881b5ed",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard_mac64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/shuffleboard/shuffleboard/2022.1.1-beta-1/shuffleboard-2022.1.1-beta-1-mac64.jar",
+        sha256 = "a28e1b869c9d7baeb4c1775e485147c4fb586b0fbc61da79ecdea93af57b7408",
+    )
+    maybe(
+        http_jar,
+        name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard_win64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/shuffleboard/shuffleboard/2022.1.1-beta-1/shuffleboard-2022.1.1-beta-1-win64.jar",
+        sha256 = "3271f09fc3f990964a402b47cdc1c08c1219fe01cb59d33fb9742b2e069fbf9c",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_glass_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/Glass/2022.1.1-beta-1/Glass-2022.1.1-beta-1-windowsx86-64.zip",
+        sha256 = "61b5d458f06afb4db00e37182c26899f3cc0d94d7831cb0b6a071dca7bf136c8",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_glass_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/Glass/2022.1.1-beta-1/Glass-2022.1.1-beta-1-linuxx86-64.zip",
+        sha256 = "2f0e3deacc8ee86906a2b40d37d11766397103aa8e211bfbcc8adf5803b848bd",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_glass_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/Glass/2022.1.1-beta-1/Glass-2022.1.1-beta-1-osxx86-64.zip",
+        sha256 = "798928072fb1210984cc4f891567d4595080a0d009c4704065ccb0b054830773",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_outlineviewer_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/OutlineViewer/2022.1.1-beta-1/OutlineViewer-2022.1.1-beta-1-windowsx86-64.zip",
+        sha256 = "b9c80208ce59344b2170f49c37bf69e90c29161921a302398643949614a7d7d7",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_outlineviewer_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/OutlineViewer/2022.1.1-beta-1/OutlineViewer-2022.1.1-beta-1-linuxx86-64.zip",
+        sha256 = "99a7a29752d14caab11a0bd6fdb2e0aecf215ea0b5b52da9fa05336902e38c60",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_outlineviewer_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/OutlineViewer/2022.1.1-beta-1/OutlineViewer-2022.1.1-beta-1-osxx86-64.zip",
+        sha256 = "7d32f193cbbcb692ccfbba3edf582261dc40fed9cdfbde042f71933d84193161",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_sysid_windowsx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SysId/2022.1.1-beta-1/SysId-2022.1.1-beta-1-windowsx86-64.zip",
+        sha256 = "4b417e19c18b38cc2d887db45ccdcc0511a1c9dc7b03146cb3d693e36abde912",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_sysid_linuxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SysId/2022.1.1-beta-1/SysId-2022.1.1-beta-1-linuxx86-64.zip",
+        sha256 = "7d2eaebb9d465a58fa1684538508dd693431b7759462a6a445ab44655caadd8b",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    maybe(
+        http_archive,
+        name = "__bazelrio_edu_wpi_first_tools_sysid_osxx86-64",
+        url = "https://frcmaven.wpi.edu/release/edu/wpi/first/tools/SysId/2022.1.1-beta-1/SysId-2022.1.1-beta-1-osxx86-64.zip",
+        sha256 = "001ed38d1aa29828a717cfb5a041e3d5ed899cc3bd4ba38bac965f19bc0e221b",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
     )

--- a/bazelrio/libraries/tools/BUILD
+++ b/bazelrio/libraries/tools/BUILD
@@ -1,0 +1,1 @@
+exports_files(["executable_launcher.sh"])

--- a/bazelrio/libraries/tools/executable_launcher.sh
+++ b/bazelrio/libraries/tools/executable_launcher.sh
@@ -1,0 +1,18 @@
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+
+
+REPO_NAME=$1
+SUBPATH=$2
+EXE_NAME=$3
+"$(rlocation $REPO_NAME/$SUBPATH/$EXE_NAME)"

--- a/bazelrio/libraries/tools/glass/BUILD
+++ b/bazelrio/libraries/tools/glass/BUILD
@@ -3,4 +3,5 @@ load("@bazelrio//libraries/tools:tool_launchers.bzl", "executable_tool_launcher"
 executable_tool_launcher(
     name = "glass",
     base_repo_name = "__bazelrio_edu_wpi_first_tools_glass",
+    macos_app = "Glass.app",
 )

--- a/bazelrio/libraries/tools/glass/BUILD
+++ b/bazelrio/libraries/tools/glass/BUILD
@@ -1,0 +1,6 @@
+load("@bazelrio//libraries/tools:tool_launchers.bzl", "executable_tool_launcher")
+
+executable_tool_launcher(
+    name = "glass",
+    base_repo_name = "__bazelrio_edu_wpi_first_tools_glass",
+)

--- a/bazelrio/libraries/tools/pathweaver/BUILD
+++ b/bazelrio/libraries/tools/pathweaver/BUILD
@@ -1,0 +1,7 @@
+load("@bazelrio//libraries/tools:tool_launchers.bzl", "java_tool_launcher")
+
+java_tool_launcher(
+    name = "pathweaver",
+    base_repo_name = "__bazelrio_edu_wpi_first_tools_pathweaver",
+    main_class = "edu.wpi.first.pathweaver.Main",
+)

--- a/bazelrio/libraries/tools/robotbuilder/BUILD
+++ b/bazelrio/libraries/tools/robotbuilder/BUILD
@@ -1,0 +1,5 @@
+java_binary(
+    name = "robotbuilder",
+    main_class = "robotbuilder.RobotBuilder",
+    runtime_deps = ["@__bazelrio_edu_wpi_first_tools_robotbuilder//jar"],
+)

--- a/bazelrio/libraries/tools/shuffleboard/BUILD
+++ b/bazelrio/libraries/tools/shuffleboard/BUILD
@@ -1,0 +1,7 @@
+load("@bazelrio//libraries/tools:tool_launchers.bzl", "java_tool_launcher")
+
+java_tool_launcher(
+    name = "shuffleboard",
+    base_repo_name = "__bazelrio_edu_wpi_first_shuffleboard_shuffleboard",
+    main_class = "edu.wpi.first.shuffleboard.app.Main",
+)

--- a/bazelrio/libraries/tools/smartdashboard/BUILD
+++ b/bazelrio/libraries/tools/smartdashboard/BUILD
@@ -1,0 +1,7 @@
+load("@bazelrio//libraries/tools:tool_launchers.bzl", "java_tool_launcher")
+
+java_tool_launcher(
+    name = "smartdashboard",
+    base_repo_name = "__bazelrio_edu_wpi_first_tools_smartdashboard",
+    main_class = "edu.wpi.first.smartdashboard.SmartDashboard",
+)

--- a/bazelrio/libraries/tools/tool_launchers.bzl
+++ b/bazelrio/libraries/tools/tool_launchers.bzl
@@ -1,8 +1,12 @@
-def executable_tool_launcher(name, base_repo_name):
+def executable_tool_launcher(name, base_repo_name, macos_app = None):
+    macos_subpath = "osx/x86-64"
+    if macos_app != None:
+        macos_subpath += "/" + macos_app + "/Contents/MacOS"
+
     subpath = select({
         "@bazel_tools//src/conditions:windows": ["windows/x86-64"],
-        "@bazel_tools//src/conditions:linux_x86_64": [],
-        "@bazel_tools//src/conditions:darwin": [],
+        "@bazel_tools//src/conditions:linux_x86_64": ["linux/x86-64"],
+        "@bazel_tools//src/conditions:darwin": [macos_subpath],
     })
 
     exe_name = select({

--- a/bazelrio/libraries/tools/tool_launchers.bzl
+++ b/bazelrio/libraries/tools/tool_launchers.bzl
@@ -1,0 +1,43 @@
+def executable_tool_launcher(name, base_repo_name):
+    subpath = select({
+        "@bazel_tools//src/conditions:windows": ["windows/x86-64"],
+        "@bazel_tools//src/conditions:linux_x86_64": [],
+        "@bazel_tools//src/conditions:darwin": [],
+    })
+
+    exe_name = select({
+        "@bazel_tools//src/conditions:windows": [name + ".exe"],
+        "@bazel_tools//src/conditions:linux_x86_64": [name],
+        "@bazel_tools//src/conditions:darwin": [name],
+    })
+
+    data = select({
+        "@bazel_tools//src/conditions:windows": ["@" + base_repo_name + "_windowsx86-64//:all"],
+        "@bazel_tools//src/conditions:linux_x86_64": ["@" + base_repo_name + "_linuxx86-64//:all"],
+        "@bazel_tools//src/conditions:darwin": ["@" + base_repo_name + "_osxx86-64//:all"],
+    })
+
+    repo_name = select({
+        "@bazel_tools//src/conditions:windows": [base_repo_name + "_windowsx86-64"],
+        "@bazel_tools//src/conditions:linux_x86_64": [base_repo_name + "_linuxx86-64"],
+        "@bazel_tools//src/conditions:darwin": [base_repo_name + "_osxx86-64"],
+    })
+
+    native.sh_binary(
+        name = name,
+        srcs = ["@bazelrio//libraries/tools:executable_launcher.sh"],
+        data = data,
+        args = repo_name + subpath + exe_name,
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+    )
+
+def java_tool_launcher(name, main_class, base_repo_name):
+    native.java_binary(
+        name = name,
+        main_class = main_class,
+        runtime_deps = select({
+            "@bazel_tools//src/conditions:windows": ["@" + base_repo_name + "_win64//jar"],
+            "@bazel_tools//src/conditions:linux_x86_64": ["@" + base_repo_name + "_linux64//jar"],
+            "@bazel_tools//src/conditions:darwin": ["@" + base_repo_name + "_mac64//jar"],
+        }),
+    )

--- a/bazelrio/toolchains/jdk/toolchain_config.bzl
+++ b/bazelrio/toolchains/jdk/toolchain_config.bzl
@@ -1,0 +1,43 @@
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def configure_java_toolchain():
+    VERSION = "11.0.12+7"
+    URL = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-" + VERSION + "/OpenJDK11U-jdk_{}_hotspot_" + VERSION.replace("+", "_") + ".zip"
+    
+
+    remote_java_repository(
+        name = "roboriojdk_windows",
+        prefix = "roboriojdk", 
+        version = "11",            
+        exec_compatible_with = [
+            "@platforms//os:windows",
+        ],
+        urls = [URL.format("x64_windows")],             
+        sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
+        strip_prefix = "jdk-" + VERSION
+    )
+
+    remote_java_repository(
+        name = "roboriojdk_linux",
+        prefix = "roboriojdk", 
+        version = "11",            
+        exec_compatible_with = [
+            "@platforms//os:linux",
+        ],
+        urls = [URL.format("x64_linux")],       
+        # sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
+        strip_prefix = "jdk-" + VERSION
+    )
+
+    remote_java_repository(
+        name = "roboriojdk_osx",
+        prefix = "roboriojdk", 
+        version = "11",            
+        exec_compatible_with = [
+            "@platforms//os:osx",
+        ],
+        urls = [URL.format("x64_mac")],         
+        # sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
+        strip_prefix = "jdk-" + VERSION
+    )

--- a/bazelrio/toolchains/jdk/toolchain_config.bzl
+++ b/bazelrio/toolchains/jdk/toolchain_config.bzl
@@ -13,7 +13,7 @@ def configure_java_toolchain():
         exec_compatible_with = [
             "@platforms//os:windows",
         ],
-        urls = [URL.format("x64_windows", ".zip")],
+        urls = [URL.format("x64_windows", "zip")],
         sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
         strip_prefix = "jdk-" + VERSION,
     )
@@ -25,8 +25,8 @@ def configure_java_toolchain():
         exec_compatible_with = [
             "@platforms//os:linux",
         ],
-        urls = [URL.format("x64_linux", ".tar.gz")],
-        # sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
+        urls = [URL.format("x64_linux", "tar.gz")],
+        sha256 = "8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2",
         strip_prefix = "jdk-" + VERSION,
     )
 
@@ -37,7 +37,7 @@ def configure_java_toolchain():
         exec_compatible_with = [
             "@platforms//os:osx",
         ],
-        urls = [URL.format("x64_mac", ".tar.gz")],
-        # sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
+        urls = [URL.format("x64_mac", "tar.gz")],
+        sha256 = "13d056ee9a57bf2d5b3af4504c8f8cf7a246c4dff78f96b70dd05dad98075855",
         strip_prefix = "jdk-" + VERSION,
     )

--- a/bazelrio/toolchains/jdk/toolchain_config.bzl
+++ b/bazelrio/toolchains/jdk/toolchain_config.bzl
@@ -1,43 +1,43 @@
-
 load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
 
 def configure_java_toolchain():
+    # Based on the wpilib downloader
+    # https://github.com/wpilibsuite/WPILibInstaller-Avalonia/blob/8a0bee9841ba645108a32ec818b7d1a7a3afe014/scripts/jdk.gradle
     VERSION = "11.0.12+7"
-    URL = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-" + VERSION + "/OpenJDK11U-jdk_{}_hotspot_" + VERSION.replace("+", "_") + ".zip"
-    
+    URL = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-" + VERSION + "/OpenJDK11U-jdk_{}_hotspot_" + VERSION.replace("+", "_") + ".{}"
 
     remote_java_repository(
         name = "roboriojdk_windows",
-        prefix = "roboriojdk", 
-        version = "11",            
+        prefix = "roboriojdk",
+        version = "11",
         exec_compatible_with = [
             "@platforms//os:windows",
         ],
-        urls = [URL.format("x64_windows")],             
+        urls = [URL.format("x64_windows", ".zip")],
         sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
-        strip_prefix = "jdk-" + VERSION
+        strip_prefix = "jdk-" + VERSION,
     )
 
     remote_java_repository(
         name = "roboriojdk_linux",
-        prefix = "roboriojdk", 
-        version = "11",            
+        prefix = "roboriojdk",
+        version = "11",
         exec_compatible_with = [
             "@platforms//os:linux",
         ],
-        urls = [URL.format("x64_linux")],       
+        urls = [URL.format("x64_linux", ".tar.gz")],
         # sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
-        strip_prefix = "jdk-" + VERSION
+        strip_prefix = "jdk-" + VERSION,
     )
 
     remote_java_repository(
         name = "roboriojdk_osx",
-        prefix = "roboriojdk", 
-        version = "11",            
+        prefix = "roboriojdk",
+        version = "11",
         exec_compatible_with = [
             "@platforms//os:osx",
         ],
-        urls = [URL.format("x64_mac")],         
+        urls = [URL.format("x64_mac", ".tar.gz")],
         # sha256 = "c54123dd4b0d6473221539e7003b8ca1c1757c5588c46465565b03bf8781f807",
-        strip_prefix = "jdk-" + VERSION
+        strip_prefix = "jdk-" + VERSION,
     )

--- a/bazelrio/toolchains/jdk/toolchain_config.bzl
+++ b/bazelrio/toolchains/jdk/toolchain_config.bzl
@@ -39,5 +39,5 @@ def configure_java_toolchain():
         ],
         urls = [URL.format("x64_mac", "tar.gz")],
         sha256 = "13d056ee9a57bf2d5b3af4504c8f8cf7a246c4dff78f96b70dd05dad98075855",
-        strip_prefix = "jdk-" + VERSION,
+        strip_prefix = "jdk-" + VERSION + "/Contents/Home",
     )

--- a/examples/cpp_example/.bazelrc
+++ b/examples/cpp_example/.bazelrc
@@ -3,6 +3,7 @@ try-import user.bazelrc
 build --incompatible_enable_cc_toolchain_resolution
 build --enable_platform_specific_config
 build --experimental_enable_runfiles  # Needed explicitly on Windows
+build --java_runtime_version=roboriojdk_11
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.
 # build --experimental_use_sandboxfs

--- a/examples/cpp_example/.bazelrc
+++ b/examples/cpp_example/.bazelrc
@@ -3,7 +3,6 @@ try-import user.bazelrc
 build --incompatible_enable_cc_toolchain_resolution
 build --enable_platform_specific_config
 build --experimental_enable_runfiles  # Needed explicitly on Windows
-build --java_runtime_version=roboriojdk_11
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.
 # build --experimental_use_sandboxfs

--- a/examples/cpp_example/WORKSPACE
+++ b/examples/cpp_example/WORKSPACE
@@ -20,8 +20,3 @@ pip_install(
     name = "__bazelrio_wpiformat_pip_deps",
     requirements = "@bazelrio//scripts/wpiformat:requirements.txt",
 )
-
-# Necessary if you want to run things that need java, like the wpi tools (shuffleboard, pathweaver, etc)
-load("@bazelrio//toolchains/jdk:toolchain_config.bzl", "configure_java_toolchain")
-
-configure_java_toolchain()

--- a/examples/cpp_example/WORKSPACE
+++ b/examples/cpp_example/WORKSPACE
@@ -20,3 +20,8 @@ pip_install(
     name = "__bazelrio_wpiformat_pip_deps",
     requirements = "@bazelrio//scripts/wpiformat:requirements.txt",
 )
+
+# Necessary if you want to run things that need java, like the wpi tools (shuffleboard, pathweaver, etc)
+load("@bazelrio//toolchains/jdk:toolchain_config.bzl", "configure_java_toolchain")
+
+configure_java_toolchain()

--- a/examples/java_example/.bazelrc
+++ b/examples/java_example/.bazelrc
@@ -3,6 +3,7 @@ try-import user.bazelrc
 build --incompatible_enable_cc_toolchain_resolution
 build --enable_platform_specific_config
 build --enable_runfiles  # Needed explicitly on Windows
+build --java_runtime_version=roboriojdk_11
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.
 # build --experimental_use_sandboxfs

--- a/examples/java_example/WORKSPACE
+++ b/examples/java_example/WORKSPACE
@@ -19,8 +19,11 @@ maybe(
 )
 
 load("@bazelrio//:deps.bzl", "setup_bazelrio_dependencies")
+load("@bazelrio//toolchains/jdk:toolchain_config.bzl", "configure_java_toolchain")
 
 setup_bazelrio_dependencies()
+
+configure_java_toolchain()
 
 register_toolchains("@bazelrio//toolchains/roborio")
 

--- a/scripts/templates/single_dep_group.jinja
+++ b/scripts/templates/single_dep_group.jinja
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazelrio//:deps_utils.bzl", "cc_library_headers", "cc_library_shared", "cc_library_static")
@@ -29,3 +29,26 @@ def setup_{{maven_dependency.name}}_{{maven_dependency.underscore_version}}_depe
     )
     {%- endfor %}
 
+
+    {%- for tool_dep in maven_dependency._java_native_tools %}
+    {%- for resource in tool_dep.resources %}
+    maybe(
+        http_jar,
+        name = "{{tool_dep.get_archive_name(resource)}}",
+        url = "{{tool_dep.get_url(resource)}}",
+        sha256 = "{{tool_dep.get_sha256(resource)}}",
+    )
+    {%- endfor %}
+    {%- endfor %}
+
+    {%- for tool_dep in maven_dependency._executable_tools %}
+    {%- for resource in tool_dep.resources %}
+    maybe(
+        http_archive,
+        name = "{{tool_dep.get_archive_name(resource)}}",
+        url = "{{tool_dep.get_url(resource)}}",
+        sha256 = "{{tool_dep.get_sha256(resource)}}",
+        build_file_content = "filegroup(name='all', srcs=glob(['**']), visibility=['//visibility:public'])",
+    )
+    {%- endfor %}
+    {%- endfor %}

--- a/scripts/wpilib_dependencies.py
+++ b/scripts/wpilib_dependencies.py
@@ -25,6 +25,22 @@ def _halsim_dependency(maven_dep, artifact_name):
     )
 
 
+def _java_tool(maven_dep, artifact_name, group_id="edu.wpi.first.tools", native_platforms=["linux64", "mac64", "win64"]):
+    if native_platforms:
+        maven_dep.add_java_native_tool(artifact_name=artifact_name, group_id=group_id, resources=native_platforms)
+    else:
+        pass
+
+def _executable_tool(maven_dep, artifact_name, group_id="edu.wpi.first.tools"):
+    native_platforms = default_native_shared_platforms()
+
+    maven_dep.add_executable_tool(
+        artifact_name=artifact_name,
+        group_id=group_id,
+        resources=native_platforms,
+    )
+
+
 def get_wpilib_dependencies():
 
     MAVEN_URL = "https://frcmaven.wpi.edu/release"
@@ -67,5 +83,19 @@ def get_wpilib_dependencies():
 
         for artifact in halsim_deps:
             _halsim_dependency(maven_dep, artifact)
+
+        _executable_tool(maven_dep, "Glass")
+        _java_tool(maven_dep, "SmartDashboard")
+        _java_tool(maven_dep, "PathWeaver")
+        _java_tool(maven_dep, "RobotBuilder", native_platforms=[""])
+        _java_tool(maven_dep, "shuffleboard", group_id="edu.wpi.first.shuffleboard")
+
+        if "2021" in version:
+            _java_tool(maven_dep, "OutlineViewer")
+        elif "2022" in version:
+            _executable_tool(maven_dep, "OutlineViewer")
+            _executable_tool(maven_dep, "SysId")
+        else:
+            raise Exception(f"Unknown year {version}")
 
     return dependencies


### PR DESCRIPTION
Adding launchers the tools that are supplied with gradlerio, like shuffleboard, pathweaver, etc.

Since sysid is 2022 only, and outlineviewer changed from a jar to an exe, I left those out. When we remove 2021 support I'll add them in.

Example: `bazel run @bazelrio//libraries/tools/shuffleboard`