### PR TITLE
Attempt to make Windows deploy not rely on --enable_runfiles

### DIFF
--- a/bazelrio/scripts/deploy/BUILD
+++ b/bazelrio/scripts/deploy/BUILD
@@ -9,5 +9,6 @@ py_binary(
         requirement("alive-progress"),
         requirement("blessed"),
         requirement("paramiko"),
+        "@rules_python//python/runfiles",
     ],
 )

--- a/bazelrio/scripts/deploy/BUILD
+++ b/bazelrio/scripts/deploy/BUILD
@@ -12,3 +12,5 @@ py_binary(
         "@rules_python//python/runfiles",
     ],
 )
+
+exports_files(["deploy.bat", "deploy.sh"])

--- a/bazelrio/scripts/deploy/deploy.bat
+++ b/bazelrio/scripts/deploy/deploy.bat
@@ -1,4 +1,5 @@
 @echo off
+:: TODO: remove all deploy runfiles machinery when https://github.com/bazelbuild/rules_kotlin/issues/629 is fixed.
 for /f "tokens=1,2" %%G in (MANIFEST) do ^
 if "%%G" == "{DEPLOY_TOOL}" ^
 "%%H" --robot_binary {ROBOT_BINARY} --team_number {TEAM_NUMBER} --robot_command "{ROBOT_COMMAND}" --dynamic_libraries {DYNAMIC_LIBRARIES} %*

--- a/bazelrio/scripts/deploy/deploy.bat
+++ b/bazelrio/scripts/deploy/deploy.bat
@@ -1,0 +1,4 @@
+@echo off
+for /f "tokens=1,2" %%G in (MANIFEST) do ^
+if "%%G" == "{DEPLOY_TOOL}" ^
+"%%H" --robot_binary {ROBOT_BINARY} --team_number {TEAM_NUMBER} --robot_command "{ROBOT_COMMAND}" --dynamic_libraries {DYNAMIC_LIBRARIES} %*

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -157,7 +157,7 @@ def deploy(argv):
 
         # copy new robot binary
         progress_bar.text(binary_name)
-        with open(r.Rlocation(os.path.join(__name__, args.robot_binary)), "rb") as robot_binary_fo:
+        with open(r.Rlocation(os.path.join("__main__", args.robot_binary)), "rb") as robot_binary_fo:
             transfer_file(client, sftp_client, robot_binary_fo, destination_path, args.verbose)
         sftp_client.chmod(destination_path, DEPLOYED_FILE_PERMS)
         sftp_client.chown(destination_path, LVUSER_UID, LVUSER_GID)
@@ -186,7 +186,7 @@ def deploy(argv):
         for dylib_path in args.dynamic_libraries:
             dylib_name = basename(dylib_path)
             progress_bar.text(dylib_name)
-            with open(r.Rlocation(os.path.join(__name__, dylib_path)), "rb") as dylib_fo:
+            with open(r.Rlocation(os.path.join("__main__", dylib_path)), "rb") as dylib_fo:
                 transfer_file(client, sftp_client, dylib_fo, f"{DYLIB_DIR}{dylib_name}", args.verbose)
             progress_bar()
 

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -133,7 +133,11 @@ def deploy(argv):
     args = parser.parse_args(argv)
 
     with get_progress_bar(len(args.dynamic_libraries) + 1) as progress_bar:
-        r = runfiles.CreateManifestBased("MANIFEST")
+        # TODO: remove all deploy runfiles machinery when https://github.com/bazelbuild/rules_kotlin/issues/629 is fixed.
+        if os.name != "nt":
+            r = runfiles.Create()
+        else:
+            r = runfiles.CreateManifestBased("MANIFEST")
 
         client = establish_connection(args.team_number, args.verbose)
         sftp_client = client.open_sftp()

--- a/bazelrio/scripts/deploy/deploy.py
+++ b/bazelrio/scripts/deploy/deploy.py
@@ -133,7 +133,7 @@ def deploy(argv):
     args = parser.parse_args(argv)
 
     with get_progress_bar(len(args.dynamic_libraries) + 1) as progress_bar:
-        r = runfiles.Create()
+        r = runfiles.CreateManifestBased("MANIFEST")
 
         client = establish_connection(args.team_number, args.verbose)
         sftp_client = client.open_sftp()
@@ -157,7 +157,7 @@ def deploy(argv):
 
         # copy new robot binary
         progress_bar.text(binary_name)
-        with open(r.Rlocation(os.path.join("__main__", args.robot_binary)), "rb") as robot_binary_fo:
+        with open(r.Rlocation(args.robot_binary), "rb") as robot_binary_fo:
             transfer_file(client, sftp_client, robot_binary_fo, destination_path, args.verbose)
         sftp_client.chmod(destination_path, DEPLOYED_FILE_PERMS)
         sftp_client.chown(destination_path, LVUSER_UID, LVUSER_GID)
@@ -186,7 +186,7 @@ def deploy(argv):
         for dylib_path in args.dynamic_libraries:
             dylib_name = basename(dylib_path)
             progress_bar.text(dylib_name)
-            with open(r.Rlocation(os.path.join("__main__", dylib_path)), "rb") as dylib_fo:
+            with open(r.Rlocation(dylib_path), "rb") as dylib_fo:
                 transfer_file(client, sftp_client, dylib_fo, f"{DYLIB_DIR}{dylib_name}", args.verbose)
             progress_bar()
 

--- a/bazelrio/scripts/deploy/deploy.sh
+++ b/bazelrio/scripts/deploy/deploy.sh
@@ -1,0 +1,12 @@
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+$(rlocation {DEPLOY_TOOL}) --robot_binary {ROBOT_BINARY} --team_number {TEAM_NUMBER} --robot_command '{ROBOT_COMMAND}' --dynamic_libraries {DYNAMIC_LIBRARIES} $@

--- a/examples/cpp_example/.bazelrc
+++ b/examples/cpp_example/.bazelrc
@@ -2,7 +2,6 @@ try-import user.bazelrc
 
 build --incompatible_enable_cc_toolchain_resolution
 build --enable_platform_specific_config
-build --experimental_enable_runfiles  # Needed explicitly on Windows
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.
 # build --experimental_use_sandboxfs

--- a/examples/java_example/.bazelrc
+++ b/examples/java_example/.bazelrc
@@ -2,7 +2,6 @@ try-import user.bazelrc
 
 build --incompatible_enable_cc_toolchain_resolution
 build --enable_platform_specific_config
-build --enable_runfiles  # Needed explicitly on Windows
 build --java_runtime_version=roboriojdk_11
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.

--- a/examples/kotlin_example/.bazelrc
+++ b/examples/kotlin_example/.bazelrc
@@ -2,7 +2,6 @@ try-import user.bazelrc
 
 build --incompatible_enable_cc_toolchain_resolution
 build --enable_platform_specific_config
-# build --enable_runfiles  # Needed explicitly on Windows
 build --java_runtime_version=roboriojdk_11
 
 # Uncomment me on macOS and Linux. See https://github.com/bazelbuild/sandboxfs/blob/master/INSTALL.md.


### PR DESCRIPTION
Only tested on macOS, but I will see if I can try this on Windows later today.