### PR TITLE
M1 mac support

### DIFF
--- a/bazelrio/toolchains/roborio/BUILD
+++ b/bazelrio/toolchains/roborio/BUILD
@@ -3,6 +3,7 @@ load(":toolchain_config.bzl", "cc_toolchain_config")
 cc_toolchain_config(
     name = "roborio_toolchain_config",
     host_os = select({
+        # assuming x86/ARM Macs use the same x86 WPILib toolchain
         "@bazel_tools//src/conditions:darwin": "macos",
         "@bazel_tools//src/conditions:linux_x86_64": "linux",
         "@bazel_tools//src/conditions:windows": "windows",
@@ -18,6 +19,7 @@ cc_toolchain_config(
 filegroup(
     name = "toolchains_files",
     srcs = select({
+        # assuming x86/ARM Macs use the same x86 WPILib toolchain
         "@bazel_tools//src/conditions:darwin": [
             "@__bazelrio_roborio_toolchain_macos//:all",
         ] + glob(["shims/macos/**"]),

--- a/bazelrio/toolchains/roborio/BUILD
+++ b/bazelrio/toolchains/roborio/BUILD
@@ -3,7 +3,7 @@ load(":toolchain_config.bzl", "cc_toolchain_config")
 cc_toolchain_config(
     name = "roborio_toolchain_config",
     host_os = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": "macos",
+        "@bazel_tools//src/conditions:darwin": "macos",
         "@bazel_tools//src/conditions:linux_x86_64": "linux",
         "@bazel_tools//src/conditions:windows": "windows",
         "//conditions:default": "unknown",
@@ -18,7 +18,7 @@ cc_toolchain_config(
 filegroup(
     name = "toolchains_files",
     srcs = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": [
+        "@bazel_tools//src/conditions:darwin": [
             "@__bazelrio_roborio_toolchain_macos//:all",
         ] + glob(["shims/macos/**"]),
         "@bazel_tools//src/conditions:linux_x86_64": [


### PR DESCRIPTION
Generalized darwin to both x86 and ARM for the roborio toolchain conditions to support M1 Macs. Assuming that the toolchain will stay x86 only for Macs and run on Rosetta on M1s, I think there shouldn't be any configuration differences between the architectures?