### PR TITLE
Remove static libraries for navX on macOS

### DIFF
--- a/bazelrio/libraries/cpp/kauailabs/navx/BUILD
+++ b/bazelrio/libraries/cpp/kauailabs/navx/BUILD
@@ -8,7 +8,7 @@ cc_library(
     ] + select({
         "@bazel_tools//src/conditions:windows": ["@__bazelrio_com_kauailabs_navx_frc_navx-cpp_windowsx86-64static//:static_libs"],
         "@bazel_tools//src/conditions:linux_x86_64": ["@__bazelrio_com_kauailabs_navx_frc_navx-cpp_linuxx86-64static//:static_libs"],
-        "@bazel_tools//src/conditions:darwin": ["@__bazelrio_com_kauailabs_navx_frc_navx-cpp_osxx86-64static//:static_libs"],
+        "@bazel_tools//src/conditions:darwin": [],
         "//constraints/is_roborio:roborio": ["@__bazelrio_com_kauailabs_navx_frc_navx-cpp_linuxathenastatic//:static_libs"],
     }),
 )


### PR DESCRIPTION
Attempting to use https://github.com/hedronvision/bazel-compile-commands-extractor to generate `compile_commands.json` for `clangd` support. Analysis fails due to the navX library [attempting to get](https://github.com/bazelRio/bazelRio/blob/53ba20d253268b327842073d1de33dc80bb8df60/bazelrio/libraries/cpp/kauailabs/navx/BUILD#L11) macOS static libraries, even though they [don't exist](https://github.com/bazelRio/bazelRio/blob/53ba20d253268b327842073d1de33dc80bb8df60/bazelrio/dependencies/navx/4_0_425/deps.bzl).

I removed the navX macOS dependency and analysis works (potential solution for #27) - not sure if just deleting the dependency is the best way to handle libraries that don't support a particular platform, though.