### PR TITLE
[java][sim] Getting sim working (on at least windows)

### DIFF
--- a/bazelrio/constraints/is_roborio/BUILD
+++ b/bazelrio/constraints/is_roborio/BUILD
@@ -12,6 +12,7 @@ constraint_value(
 constraint_value(
     name = "false",
     constraint_setting = ":is_roborio",
+    visibility = ["//visibility:public"],
 )
 
 config_setting(

--- a/bazelrio/dependencies/scripts/deps.bzl
+++ b/bazelrio/dependencies/scripts/deps.bzl
@@ -9,6 +9,7 @@ def setup_scripts_dependencies():
             "me.tongfei:progressbar:0.9.2",
             "net.sourceforge.argparse4j:argparse4j:0.9.0",
             "org.slf4j:slf4j-nop:1.7.32",
+            "org.ejml:ejml-simple:0.38",
         ],
         repositories = [
             "https://repo1.maven.org/maven2",

--- a/bazelrio/libraries/cpp/wpilib/simulation/halsim_gui/BUILD
+++ b/bazelrio/libraries/cpp/wpilib/simulation/halsim_gui/BUILD
@@ -2,7 +2,12 @@ cc_library(
     name = "halsim_gui",
     linkstatic = 1,
     visibility = ["//visibility:public"],
-    deps = select({
+    deps = [
+        "//libraries/cpp/wpilib/hal",
+        "//libraries/cpp/wpilib/ntcore",
+        "//libraries/cpp/wpilib/wpimath",
+        "//libraries/cpp/wpilib/wpiutil",
+    ] + select({
         "@bazel_tools//src/conditions:windows": ["@__bazelrio_edu_wpi_first_halsim_halsim_gui_windowsx86-64//:shared_libs"],
         "@bazel_tools//src/conditions:linux_x86_64": ["@__bazelrio_edu_wpi_first_halsim_halsim_gui_linuxx86-64//:shared_libs"],
         "@bazel_tools//src/conditions:darwin": ["@__bazelrio_edu_wpi_first_halsim_halsim_gui_osxx86-64//:shared_libs"],

--- a/bazelrio/libraries/cpp/wpilib/simulation/halsim_gui/BUILD
+++ b/bazelrio/libraries/cpp/wpilib/simulation/halsim_gui/BUILD
@@ -2,12 +2,7 @@ cc_library(
     name = "halsim_gui",
     linkstatic = 1,
     visibility = ["//visibility:public"],
-    deps = [
-        "//libraries/cpp/wpilib/hal",
-        "//libraries/cpp/wpilib/ntcore",
-        "//libraries/cpp/wpilib/wpimath",
-        "//libraries/cpp/wpilib/wpiutil",
-    ] + select({
+    deps = select({
         "@bazel_tools//src/conditions:windows": ["@__bazelrio_edu_wpi_first_halsim_halsim_gui_windowsx86-64//:shared_libs"],
         "@bazel_tools//src/conditions:linux_x86_64": ["@__bazelrio_edu_wpi_first_halsim_halsim_gui_linuxx86-64//:shared_libs"],
         "@bazel_tools//src/conditions:darwin": ["@__bazelrio_edu_wpi_first_halsim_halsim_gui_osxx86-64//:shared_libs"],

--- a/bazelrio/libraries/java/wpilib/wpimath/BUILD
+++ b/bazelrio/libraries/java/wpilib/wpimath/BUILD
@@ -2,6 +2,9 @@ java_import(
     name = "wpimath",
     jars = ["@__bazelrio_edu_wpi_first_wpimath_wpimath-java//jar:file"],
     visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@__bazelrio_maven_deps//:org_ejml_ejml_simple",
+    ],
     deps = [
         "//libraries/cpp/wpilib/wpimath:jni",
         "//libraries/java/wpilib/wpiutil",

--- a/examples/java_example/BUILD
+++ b/examples/java_example/BUILD
@@ -2,6 +2,7 @@ load("@bazelrio//:defs.bzl", "robot_java_binary")
 
 robot_java_binary(
     name = "robot",
+    halsim_deps = ["@bazelrio//libraries/cpp/wpilib/simulation/halsim_gui"],
     main_class = "frc.robot.Main",
     team_number = 1337,
     runtime_deps = [

--- a/examples/kotlin_example/BUILD
+++ b/examples/kotlin_example/BUILD
@@ -2,6 +2,7 @@ load("@bazelrio//:defs.bzl", "robot_java_binary")
 
 robot_java_binary(
     name = "robot",
+    halsim_deps = ["@bazelrio//libraries/cpp/wpilib/simulation/halsim_gui"],
     main_class = "frc.robot.Main",
     team_number = 1337,
     runtime_deps = [


### PR DESCRIPTION
"Works on my machine"

Chained shared library dependencies don't get unwrapped by bazel in the same way that they do for C++. It also doesn't seem to set the `PATH` or `LD_LIBRARY_PATH` as required, so one solution is to symlink (which on windows is a copy) the shared libraries into the path the binary is run from. This is essentially what seems to happen for C++.

This seems to work for both the java and kotlin example, as well as my monorepo. In the process of trying it on docker-ubuntu, no way to test on mac.

PS: The JNI libraries weren't quite right for CTRE and REV, and a runtime dependency was missing for wpimath.