### PR TITLE
Fixing CTRE and REV jni

### DIFF
--- a/bazelrio/dependencies/scripts/deps.bzl
+++ b/bazelrio/dependencies/scripts/deps.bzl
@@ -3,6 +3,7 @@ load("@rules_python//python:pip.bzl", "pip_install")
 
 def setup_scripts_dependencies():
     maven_install(
+        name = "__bazelrio_maven_deps",
         artifacts = [
             "com.hierynomus:sshj:0.32.0",
             "me.tongfei:progressbar:0.9.2",

--- a/bazelrio/libraries/cpp/ctre/phoenix/BUILD
+++ b/bazelrio/libraries/cpp/ctre/phoenix/BUILD
@@ -45,3 +45,37 @@ cc_library(
         ],
     }),
 )
+
+cc_library(
+    name = "jni",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@bazel_tools//src/conditions:windows": [
+            "@__bazelrio_com_ctre_phoenix_sim_cci-sim_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simtalonsrx_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simtalonfx_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simvictorspx_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simpigeonimu_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simcancoder_windowsx86-64//:shared_libs",
+        ],
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "@__bazelrio_com_ctre_phoenix_sim_cci-sim_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simtalonsrx_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simtalonfx_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simvictorspx_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simpigeonimu_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simcancoder_linuxx86-64//:shared_libs",
+        ],
+        "@bazel_tools//src/conditions:darwin": [
+            "@__bazelrio_com_ctre_phoenix_sim_cci-sim_osxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simtalonsrx_osxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simtalonfx_osxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simvictorspx_osxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simpigeonimu_osxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_sim_simcancoder_osxx86-64//:shared_libs",
+        ],
+        "//constraints/is_roborio:roborio": [
+            "@__bazelrio_com_ctre_phoenix_cci_osxx86-64//:shared_libs",
+        ],
+    }),
+)

--- a/bazelrio/libraries/cpp/rev/revlib/BUILD
+++ b/bazelrio/libraries/cpp/rev/revlib/BUILD
@@ -24,3 +24,23 @@ cc_library(
         ],
     }),
 )
+
+
+cc_library(
+    name = "jni",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@bazel_tools//src/conditions:windows": [
+            "@__bazelrio_com_revrobotics_frc_revlib-driver_windowsx86-64//:shared_libs",
+        ],
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "@__bazelrio_com_revrobotics_frc_revlib-driver_linuxx86-64//:shared_libs",
+        ],
+        "@bazel_tools//src/conditions:darwin": [
+            "@__bazelrio_com_revrobotics_frc_revlib-driver_osxx86-64//:shared_libs",
+        ],
+        "//constraints/is_roborio:roborio": [
+            "@__bazelrio_com_revrobotics_frc_revlib-driver_linuxathena//:shared_libs",
+        ],
+    }),
+)

--- a/bazelrio/libraries/cpp/rev/revlib/BUILD
+++ b/bazelrio/libraries/cpp/rev/revlib/BUILD
@@ -25,7 +25,6 @@ cc_library(
     }),
 )
 
-
 cc_library(
     name = "jni",
     visibility = ["//visibility:public"],

--- a/bazelrio/libraries/cpp/rev/sparkmax/BUILD
+++ b/bazelrio/libraries/cpp/rev/sparkmax/BUILD
@@ -24,3 +24,29 @@ cc_library(
         ],
     }),
 )
+
+cc_library(
+    name = "jni",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@bazel_tools//src/conditions:windows": [
+            "@__bazelrio_com_revrobotics_frc_sparkmax-cpp_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-driver_windowsx86-64//:shared_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-cpp_windowsx86-64//:shared_jni_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-driver_windowsx86-64//:shared_jni_libs",
+        ],
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "@__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxx86-64//:shared_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-cpp_linuxx86-64//:shared_jni_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-driver_linuxx86-64//:shared_jni_libs",
+        ],
+        "@bazel_tools//src/conditions:darwin": [
+            "@__bazelrio_com_revrobotics_frc_sparkmax-cpp_osxx86-64//:shared_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-driver_osxx86-64//:shared_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-cpp_osxx86-64//:shared_jni_libs",
+            "@__bazelrio_com_revrobotics_frc_sparkmax-driver_osxx86-64//:shared_jni_libs",
+        ],
+        "//constraints/is_roborio:roborio": [],
+    }),
+)

--- a/bazelrio/libraries/java/ctre/phoenix/BUILD
+++ b/bazelrio/libraries/java/ctre/phoenix/BUILD
@@ -6,7 +6,7 @@ java_import(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//libraries/cpp/ctre/phoenix",
+        "//libraries/cpp/ctre/phoenix:jni",
         "//libraries/java/wpilib/wpilibj",
     ],
 )

--- a/bazelrio/libraries/java/rev/revlib/BUILD
+++ b/bazelrio/libraries/java/rev/revlib/BUILD
@@ -3,7 +3,7 @@ java_import(
     jars = ["@__bazelrio_com_revrobotics_frc_revlib-java//jar:file"],
     visibility = ["//visibility:public"],
     deps = [
-        "//libraries/cpp/rev/revlib",
+        "//libraries/cpp/rev/revlib:jni",
         "//libraries/java/wpilib/wpilibj",
     ],
 )

--- a/bazelrio/libraries/java/rev/sparkmax/BUILD
+++ b/bazelrio/libraries/java/rev/sparkmax/BUILD
@@ -3,7 +3,7 @@ java_import(
     jars = ["@__bazelrio_com_revrobotics_frc_sparkmax-java//jar:file"],
     visibility = ["//visibility:public"],
     deps = [
-        "//libraries/cpp/rev/sparkmax",
+        "//libraries/cpp/rev/sparkmax:jni",
         "//libraries/java/wpilib/wpilibj",
     ],
 )

--- a/bazelrio/scripts/deploy/BUILD
+++ b/bazelrio/scripts/deploy/BUILD
@@ -3,10 +3,10 @@ java_library(
     srcs = ["Deploy.java"],
     visibility = ["//visibility:public"],
     deps = [
+        "@__bazelrio_maven_deps//:com_hierynomus_sshj",
+        "@__bazelrio_maven_deps//:me_tongfei_progressbar",
+        "@__bazelrio_maven_deps//:net_sourceforge_argparse4j_argparse4j",
+        "@__bazelrio_maven_deps//:org_slf4j_slf4j_nop",
         "@bazel_tools//tools/java/runfiles",
-        "@maven//:com_hierynomus_sshj",
-        "@maven//:me_tongfei_progressbar",
-        "@maven//:net_sourceforge_argparse4j_argparse4j",
-        "@maven//:org_slf4j_slf4j_nop",
     ],
 )


### PR DESCRIPTION
Rips out the relevant pieces from #88, since the java sim might need to be reworked for non-windows. This seems like it is necessary for even deploying the code.

The main reason you couldn't piggy back off the C++ definition, is because we build exactly as gradlerio does, which uses static libraries for some of the components instead of shared ones.