### PR TITLE
Fix bug where CTRE JNI target uses osxx86-64 workspace

### DIFF
--- a/bazelrio/libraries/cpp/ctre/phoenix/BUILD
+++ b/bazelrio/libraries/cpp/ctre/phoenix/BUILD
@@ -75,7 +75,7 @@ cc_library(
             "@__bazelrio_com_ctre_phoenix_sim_simcancoder_osxx86-64//:shared_libs",
         ],
         "//constraints/is_roborio:roborio": [
-            "@__bazelrio_com_ctre_phoenix_cci_osxx86-64//:shared_libs",
+            "@__bazelrio_com_ctre_phoenix_cci_linuxathena//:shared_libs",
         ],
     }),
 )


### PR DESCRIPTION
Ran into this bug, straightforward fix.